### PR TITLE
Bug fix for infinite amplitude in fit init

### DIFF
--- a/src/trap/detection.py
+++ b/src/trap/detection.py
@@ -1096,8 +1096,10 @@ def fit_2d_gaussian(
     rhophi = relative_yx_to_rhophi(relative_yx)
     phi = rhophi[1] * np.pi / 180.0
 
+    finite_mask = np.logical_and(np.isfinite(cutout.data), cutout.data != 0.0)
+
     g_init = models.Gaussian2D(
-        amplitude=np.nanmax(cutout.data),
+        amplitude=np.max(cutout.data[finite_mask]),
         x_mean=yx_position_cutout[1],
         y_mean=yx_position_cutout[0],
         x_stddev=x_stddev,
@@ -1112,7 +1114,6 @@ def fit_2d_gaussian(
     if fix_orientation:
         g_init.theta.fixed = True
 
-    finite_mask = np.logical_and(np.isfinite(cutout.data), cutout.data != 0.0)
     fitter = fitting.LevMarLSQFitter()
     par = fitter(g_init, xx[finite_mask], yy[finite_mask], cutout.data[finite_mask])
     model = par(xx, yy)


### PR DESCRIPTION
This is a fix for the following error that I encountered with `detection_and_characterization`:

```
astropy.modeling.fitting.NonFiniteValueError: Objective function has encountered a non-finite value, this will cause the fit to fail!
This can be caused by non-finite values in the input data or weights, which can be removed with fit(..., filter_non_finite=True), or by diverging model parameters that yield non-finite model values.
```

The issue is that the init amplitude for the fit can be inf, because only nan is filtered out. Using the `finite_mask` solves the issue.