### PR TITLE
Apply coronagraph throughput to forward model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/) and [Sem
 
 ## [Unreleased]
 
+### Added
+- Optional coronagraph throughput correction: pass a `(separation_mas, throughput)`
+  table via `TrapReductionConfig.coronagraph_transmission` to attenuate the
+  forward model by the separation-dependent coronagraph transmission, correcting
+  underestimated contrasts at small separations (#31).
+
 ### Fixed
 - **Out-of-grid stellar parameters no longer abort template matching** – `add_default_templates` built the stellar template from the solar-only `bt-nextgen` grid but passed the requested `stellar_parameters` straight to `species`' `get_model`, so a sub-solar `[Fe/H]` (or an out-of-range Teff/log g) raised `ValueError: … smaller than the lower boundary of the model grid`. Values are now clamped to the grid boundaries (via `ReadModel.get_bounds()`) before `get_model`, snapping to the nearest edge with a `warnings.warn`, so any caller's stellar parameters degrade gracefully instead of crashing.
 

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -238,6 +238,37 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Optional: coronagraph throughput correction (issue #31) --------------\n",
+    "# Close to the star the coronagraph attenuates real planet flux. Without this\n",
+    "# correction the extracted contrast at small separations is underestimated.\n",
+    "# Provide a table of separation (in mas) vs. throughput (in [0, 1], reaching 1\n",
+    "# beyond the coronagraph inner working angle). TRAP converts the mas axis to\n",
+    "# pixels internally using the instrument pixel scale, looks up the throughput\n",
+    "# at each search position, and scales the injected forward model accordingly.\n",
+    "# Left as None (the default), no correction is applied.\n",
+    "#\n",
+    "# The table can be an (N, 2) array of [separation_mas, throughput] rows, or a\n",
+    "# (separation_mas, throughput) tuple of 1-D arrays. Below the smallest tabulated\n",
+    "# separation the innermost value is used; beyond the largest it is treated as 1.\n",
+    "# Since TrapReductionConfig is frozen, use merge() to attach it:\n",
+    "#\n",
+    "# coronagraph_transmission = np.array([\n",
+    "#     [0.,   0.00],\n",
+    "#     [100., 0.30],\n",
+    "#     [200., 0.70],\n",
+    "#     [300., 0.95],\n",
+    "#     [400., 1.00],\n",
+    "# ])\n",
+    "# reduction_config = reduction_config.merge(\n",
+    "#     coronagraph_transmission=coronagraph_transmission)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/src/trap/makesource.py
+++ b/src/trap/makesource.py
@@ -4,6 +4,8 @@ Routines used in TRAP
 @author: Tim Brandt, Matthias Samland
 """
 
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
 from astropy.nddata import Cutout2D
@@ -364,3 +366,79 @@ def extract_stamps(flux_arr, pos, pa, stamp_size, image_center=None,
 
     stamps = np.array(stamps)
     return stamps, shifts
+
+
+def coronagraph_transmission_to_pixels(transmission, mas_per_pixel):
+    """Convert a coronagraph throughput table's separation axis to pixels.
+
+    Parameters
+    ----------
+    transmission : array_like
+        Either an ``(N, 2)`` array of ``[separation_mas, throughput]`` rows, or
+        a ``(separation_mas, throughput)`` tuple of 1-D arrays. Throughput must
+        lie in ``[0, 1]``.
+    mas_per_pixel : float
+        Instrument plate scale in milliarcseconds per pixel.
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted ``(N, 2)`` float array of ``[separation_pixels, throughput]``.
+    """
+    if isinstance(transmission, tuple) and len(transmission) == 2:
+        separation_mas = np.asarray(transmission[0], dtype=float)
+        throughput = np.asarray(transmission[1], dtype=float)
+    else:
+        transmission = np.asarray(transmission, dtype=float)
+        if transmission.ndim != 2 or transmission.shape[1] != 2:
+            raise ValueError(
+                "coronagraph_transmission must be an (N, 2) array or a "
+                "(separation_mas, throughput) tuple."
+            )
+        separation_mas = transmission[:, 0]
+        throughput = transmission[:, 1]
+
+    if np.any(throughput < 0.0) or np.any(throughput > 1.0):
+        warnings.warn(
+            "Coronagraph throughput values outside [0, 1] were clipped.",
+            stacklevel=2,
+        )
+    throughput = np.clip(throughput, 0.0, 1.0)
+
+    order = np.argsort(separation_mas)
+    separation_pix = separation_mas[order] / mas_per_pixel
+    throughput = throughput[order]
+
+    if not np.isclose(throughput[-1], 1.0):
+        warnings.warn(
+            "Largest-separation coronagraph throughput is not 1.0; separations "
+            "beyond the table are treated as fully transmitting (1.0).",
+            stacklevel=2,
+        )
+
+    return np.column_stack((separation_pix, throughput))
+
+
+def coronagraph_throughput_factor(separation_pix, transmission_pix):
+    """Interpolate the coronagraph throughput at a given separation in pixels.
+
+    Below the smallest tabulated separation the innermost value is used; beyond
+    the largest tabulated separation the throughput is 1.0.
+
+    Parameters
+    ----------
+    separation_pix : float
+        Separation of the candidate from the star in pixels.
+    transmission_pix : numpy.ndarray
+        Sorted ``(N, 2)`` array of ``[separation_pixels, throughput]``.
+
+    Returns
+    -------
+    float
+        Throughput scaling factor in ``[0, 1]``.
+    """
+    separation = transmission_pix[:, 0]
+    throughput = transmission_pix[:, 1]
+    return float(
+        np.interp(separation_pix, separation, throughput, left=throughput[0], right=1.0)
+    )

--- a/src/trap/parameters.py
+++ b/src/trap/parameters.py
@@ -763,6 +763,7 @@ class TrapReductionConfig:
     threshold_pixel_by_contribution: float = 0.0
     target_pix_mask_radius: Optional[float] = None
     use_relative_position: bool = False
+    coronagraph_transmission: Optional[Any] = None
     
     # Regressor selection
     annulus_width: int = 5
@@ -805,7 +806,8 @@ class TrapReductionConfig:
             stacklevel=2,
         )
         params_dict = asdict(self)
-        
+        params_dict.pop("coronagraph_transmission", None)
+
         # Filter out None values, but keep explicit None defaults where needed
         filtered_params = {}
         for k, v in params_dict.items():
@@ -841,6 +843,7 @@ class ReductionRuntimeState:
     data_crop_size: Optional[int] = None
     search_region: Optional[np.ndarray] = None       # binary mask
     ncpus: int = 4
+    coronagraph_transmission_pix: Optional[np.ndarray] = None
 
     # --- Category C: per iteration (wavelength x component) ---
     number_of_pca_regressors: int = 20
@@ -874,6 +877,7 @@ def build_runtime_state(
     stamp_sizes: np.ndarray,
     stamp_sizes_reduction: np.ndarray,
     max_shift: float,
+    mas_per_pixel: Optional[float] = None,
 ) -> ReductionRuntimeState:
     """Compute all derived values from user config + data properties.
 
@@ -899,6 +903,19 @@ def build_runtime_state(
     ReductionRuntimeState
     """
     from trap import regressor_selection  # local import to avoid circular
+
+    coronagraph_transmission_pix = None
+    transmission = getattr(config, "coronagraph_transmission", None)
+    if transmission is not None:
+        if mas_per_pixel is None:
+            raise ValueError(
+                "mas_per_pixel is required to use coronagraph_transmission."
+            )
+        from trap.makesource import coronagraph_transmission_to_pixels
+
+        coronagraph_transmission_pix = coronagraph_transmission_to_pixels(
+            transmission, mas_per_pixel
+        )
 
     # --- Category A: normalize inputs ---
     yx_anamorphism = np.array(config.yx_anamorphism)
@@ -1011,6 +1028,7 @@ def build_runtime_state(
         data_crop_size=data_crop_size,
         search_region=search_region,
         ncpus=ncpus,
+        coronagraph_transmission_pix=coronagraph_transmission_pix,
         # Category C: initial values (will be overwritten by for_iteration)
         number_of_pca_regressors=config.number_of_pca_regressors,
         temporal_components_fraction=0.0,

--- a/src/trap/reduction_wrapper.py
+++ b/src/trap/reduction_wrapper.py
@@ -12,6 +12,7 @@ import multiprocessing
 import os
 from collections import OrderedDict
 
+import astropy.units as u
 import numpy as np
 import ray
 from astropy.io import fits
@@ -129,6 +130,13 @@ def trap_one_position(
     planet_absolute_yx_pos = image_coordinates.relative_yx_to_absolute_yx(
         signal_position, yx_center
     )
+
+    if runtime.coronagraph_transmission_pix is not None:
+        separation_pix = np.hypot(signal_position[0], signal_position[1])
+        # amplitude_modulation is shared read-only via ray.put: copy, never mutate.
+        amplitude_modulation = amplitude_modulation * makesource.coronagraph_throughput_factor(
+            separation_pix, runtime.coronagraph_transmission_pix
+        )
 
     injected_model_cube = np.zeros_like(data)
     injected_model_cube = makesource.inject_model_into_data(
@@ -1316,6 +1324,7 @@ def run_complete_reduction(
         stamp_sizes=stamp_sizes,
         stamp_sizes_reduction=stamp_sizes_reduction,
         max_shift=max_shift,
+        mas_per_pixel=(1 * u.pixel).to(u.mas, equivalencies=instrument.pixel_scale).value,
     )
     data_crop_size = runtime.data_crop_size
 

--- a/tests/test_coronagraph_throughput.py
+++ b/tests/test_coronagraph_throughput.py
@@ -1,0 +1,119 @@
+import numpy as np
+import pytest
+
+from trap.makesource import (
+    coronagraph_throughput_factor,
+    coronagraph_transmission_to_pixels,
+)
+from trap.parameters import TrapReductionConfig, build_runtime_state
+
+
+def test_to_pixels_converts_and_sorts():
+    # 10 mas/pixel: 100 mas -> 10 pix, 50 mas -> 5 pix; input unsorted
+    table_mas = np.array([[100.0, 1.0], [50.0, 0.5], [0.0, 0.0]])
+    out = coronagraph_transmission_to_pixels(table_mas, mas_per_pixel=10.0)
+    assert out.shape == (3, 2)
+    np.testing.assert_allclose(out[:, 0], [0.0, 5.0, 10.0])
+    np.testing.assert_allclose(out[:, 1], [0.0, 0.5, 1.0])
+
+
+def test_to_pixels_accepts_pair():
+    sep_mas = np.array([0.0, 50.0, 100.0])
+    throughput = np.array([0.0, 0.5, 1.0])
+    out = coronagraph_transmission_to_pixels((sep_mas, throughput), mas_per_pixel=10.0)
+    np.testing.assert_allclose(out[:, 0], [0.0, 5.0, 10.0])
+
+
+def test_to_pixels_warns_when_last_not_one():
+    table_mas = np.array([[0.0, 0.0], [100.0, 0.8]])
+    with pytest.warns(UserWarning):
+        coronagraph_transmission_to_pixels(table_mas, mas_per_pixel=10.0)
+
+
+def test_factor_interpolates():
+    table_pix = np.array([[0.0, 0.0], [5.0, 0.5], [10.0, 1.0]])
+    assert coronagraph_throughput_factor(2.5, table_pix) == pytest.approx(0.25)
+
+
+def test_factor_beyond_table_is_one():
+    table_pix = np.array([[0.0, 0.0], [10.0, 1.0]])
+    assert coronagraph_throughput_factor(50.0, table_pix) == pytest.approx(1.0)
+
+
+def test_factor_below_table_clamps_to_first():
+    table_pix = np.array([[3.0, 0.2], [10.0, 1.0]])
+    assert coronagraph_throughput_factor(0.0, table_pix) == pytest.approx(0.2)
+
+
+def _minimal_runtime(coronagraph_transmission, mas_per_pixel):
+    config = TrapReductionConfig(
+        search_region_outer_bound=20,
+        data_auto_crop=False,
+        data_crop_size=101,
+        coronagraph_transmission=coronagraph_transmission,
+    )
+    return build_runtime_state(
+        config=config,
+        data_shape=(1, 4, 101, 101),
+        stamp_sizes=np.array([21]),
+        stamp_sizes_reduction=np.array([19]),
+        max_shift=0.0,
+        mas_per_pixel=mas_per_pixel,
+    )
+
+
+def test_runtime_builds_pixel_table():
+    table_mas = np.array([[0.0, 0.0], [50.0, 0.5], [100.0, 1.0]])
+    runtime = _minimal_runtime(table_mas, mas_per_pixel=10.0)
+    assert runtime.coronagraph_transmission_pix is not None
+    np.testing.assert_allclose(runtime.coronagraph_transmission_pix[:, 0], [0.0, 5.0, 10.0])
+
+
+def test_runtime_table_none_by_default():
+    runtime = _minimal_runtime(None, mas_per_pixel=10.0)
+    assert runtime.coronagraph_transmission_pix is None
+
+
+def test_to_pixels_two_point_pair():
+    out = coronagraph_transmission_to_pixels(
+        (np.array([0.0, 100.0]), np.array([0.0, 1.0])), mas_per_pixel=10.0
+    )
+    np.testing.assert_allclose(out[:, 0], [0.0, 10.0])
+    np.testing.assert_allclose(out[:, 1], [0.0, 1.0])
+
+
+def test_to_pixels_clips_and_warns_out_of_range():
+    table_mas = np.array([[0.0, 0.0], [100.0, 1.5]])
+    with pytest.warns(UserWarning):
+        out = coronagraph_transmission_to_pixels(table_mas, mas_per_pixel=10.0)
+    assert out[-1, 1] == pytest.approx(1.0)
+
+
+def test_runtime_requires_mas_per_pixel():
+    table_mas = np.array([[0.0, 0.0], [50.0, 0.5], [100.0, 1.0]])
+    with pytest.raises(ValueError):
+        _minimal_runtime(table_mas, mas_per_pixel=None)
+
+
+def test_to_reduction_parameters_with_transmission():
+    config = TrapReductionConfig(
+        coronagraph_transmission=np.array([[0.0, 0.0], [100.0, 1.0]])
+    )
+    with pytest.warns(DeprecationWarning):
+        config.to_reduction_parameters()
+
+
+def test_amplitude_scaling_does_not_mutate_shared_array():
+    # Mirrors the trap_one_position logic: amplitude_modulation comes from
+    # ray.put and is shared read-only across positions.
+    table_pix = np.array([[0.0, 0.0], [5.0, 0.5], [10.0, 1.0]])
+    shared = np.ones(4)
+    signal_position = np.array([0.0, 2.5])  # |pos| = 2.5 px -> throughput 0.25
+
+    separation_pix = np.hypot(signal_position[0], signal_position[1])
+    factor = coronagraph_throughput_factor(separation_pix, table_pix)
+    scaled = shared * factor
+
+    assert factor == pytest.approx(0.25)
+    np.testing.assert_allclose(scaled, np.full(4, 0.25))
+    np.testing.assert_allclose(shared, np.ones(4))  # shared untouched


### PR DESCRIPTION
Closes #31

## Summary

Make the TRAP forward model account for coronagraphic throughput as a function
of separation. Near the mask the coronagraph attenuates a companion's flux; by
scaling the injected forward-model PSF by the same throughput, extracted
contrasts (and contrast curves) are automatically corrected rather than
underestimated close to the star.

## Design

Throughput is a **single scalar per grid position**: field rotation preserves
the sky separation `|pos|`, and per-frame centering does not change it, so the
factor is looked up once per position and applied to the per-frame amplitude
modulation. Applying it at injection propagates through the linear
`contrast = data_flux / model_flux` fit, so both point-source contrasts and
contrast curves are corrected consistently.

## Changes

- **`makesource.py`:** `coronagraph_transmission_to_pixels(transmission, mas_per_pixel)`
  converts a `[separation_mas, throughput]` table (or a 2-point pair) to
  `[separation_pix, throughput]`, sorted, clipped to [0, 1] with a warning, and
  warns if the outermost throughput is not 1.0. `coronagraph_throughput_factor(separation_pix, transmission_pix)`
  interpolates, clamping to the first value inside the table and to 1.0 beyond it.
- **`parameters.py`:** add `coronagraph_transmission` to `TrapReductionConfig` and
  `coronagraph_transmission_pix` to `ReductionRuntimeState`; `build_runtime_state`
  precomputes the pixel table (needs `mas_per_pixel`). The legacy
  `to_reduction_parameters()` bridge drops the field so the deprecated
  `Reduction_parameters` constructor is unaffected.
- **`reduction_wrapper.py`:** in `trap_one_position`, scale a **copy** of the
  shared amplitude modulation by the throughput factor at the signal separation
  (never mutates the ray-shared array).
- Tests (13), CHANGELOG, and a commented-out usage cell in `examples/tutorial.ipynb`.

## Persistence / detection

The full search saves the modern `reduction_config.obj` (which carries
`coronagraph_transmission`); the detection module prefers that file, `.merge()`
preserves the field, and the candidate spectrum re-reduction rebuilds
`coronagraph_transmission_pix`, so extraction uses the identical correction as
the search.

## Testing

`pixi run -e dev pytest tests/test_coronagraph_throughput.py -v` — 13 passed.
