### PR TITLE
Replace library prints with standard-library logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/) and [Sem
 ### Fixed
 - **Out-of-grid stellar parameters no longer abort template matching** – `add_default_templates` built the stellar template from the solar-only `bt-nextgen` grid but passed the requested `stellar_parameters` straight to `species`' `get_model`, so a sub-solar `[Fe/H]` (or an out-of-range Teff/log g) raised `ValueError: … smaller than the lower boundary of the model grid`. Values are now clamped to the grid boundaries (via `ReadModel.get_bounds()`) before `get_model`, snapping to the nearest edge with a `warnings.warn`, so any caller's stellar parameters degrade gracefully instead of crashing.
 
+### Changed
+- **Library logging instead of `print`** – Replaced the library's `print()` calls with standard-library `logging` (per-module `logging.getLogger(__name__)`, a single `NullHandler` at the package root). The library sets no levels or handlers of its own; callers control verbosity via `logging.getLogger("trap").setLevel(...)`, so a driver such as `spherical` can quiet routine output down to warnings/errors and keep its progress bar intact. Per-position diagnostics on the Ray worker path are `debug` only. `likelihood_tools.py` and `embed_shell.py` are unchanged.
+
 ## [1.3.0] - 2026-07-03
 
 ### Added

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -42,12 +42,20 @@
   },
   {
    "cell_type": "markdown",
+   "source": "## Logging\n\nTRAP logs through Python's `logging` and stays silent by default. Opt in to see output, and use `logging.getLogger(\"trap\").setLevel(...)` to control verbosity (`WARNING` for quiet batch runs).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "import logging\n\n# TRAP is a library: it logs through the standard `logging` module and installs\n# only a NullHandler, so by default you see *nothing*. Configure a handler once\n# to see its output, then dial the level to taste:\n#   INFO  -> stage milestones (number of positions, per-wavelength progress)\n#   DEBUG -> timing, shapes, per-position detail (verbose)\n#   WARNING (default recommendation for batch runs) -> only skips/problems\nlogging.basicConfig(level=logging.INFO, format=\"%(name)s: %(message)s\")\nlogging.getLogger(\"trap\").setLevel(logging.INFO)\n\n# To silence routine output (e.g. when driving many reductions from another\n# tool and keeping an outer progress bar clean), raise the level instead:\n#   logging.getLogger(\"trap\").setLevel(logging.WARNING)",
    "metadata": {},
-   "source": [
-    "## Setting up the Instrument and Reduction parameters\n",
-    "\n",
-    "We need the pipeline to be aware of some attributes of the instrument we are using, like the pixel scale to translate coordinates and angular sizes, and the telescope diameter which is needed to compute the theoretical size of the point-spread function of the telescope. For this we create an Instrument-class object. Detector properties such as the read-noise and gain can be additionally specified if you want TRAP to take them into account when modeling the systematics. If you provide a variance data cube that already contains all the uncertainties of the input data later in, just leave them on their default value so that you do not take them into account twice. The example given below is for the test data packaged with the pipeline."
-   ]
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "import logging\n\nlogging.basicConfig(level=logging.INFO, format=\"%(name)s: %(message)s\")\nlogging.getLogger(\"trap\").setLevel(logging.INFO)  # or logging.WARNING to quiet it"
   },
   {
    "cell_type": "code",

--- a/src/trap/__init__.py
+++ b/src/trap/__init__.py
@@ -1,4 +1,8 @@
+import logging
+
 from . import _version
+
+logging.getLogger("trap").addHandler(logging.NullHandler())
 
 try:
     __version__ = _version.version

--- a/src/trap/detection.py
+++ b/src/trap/detection.py
@@ -6,6 +6,7 @@ Routines used in TRAP
 """
 
 import copy
+import logging
 import os
 import warnings
 from collections import OrderedDict
@@ -43,6 +44,8 @@ from trap.utils import (
     save_object,
     subtract_angles,
 )
+
+logger = logging.getLogger(__name__)
 
 # plt.style.use("paper")
 
@@ -760,9 +763,7 @@ def plot_contrast_curve(
         try:
             pdf.savefig(bbox_inches="tight")
         except RuntimeError:
-            print(
-                "Could not output pdf-version of contrast curve (this may be a Mac issue)."
-            )
+            logger.warning("Could not output pdf-version of contrast curve (this may be a Mac issue).")
         pdf.close()
 
     if show is True:
@@ -970,9 +971,7 @@ def plot_contrast_curve_ratio(
         try:
             pdf.savefig(bbox_inches="tight")
         except RuntimeError:
-            print(
-                "Could not output pdf-version of contrast curve (this may be a Mac issue)."
-            )
+            logger.warning("Could not output pdf-version of contrast curve (this may be a Mac issue).")
         pdf.close()
 
     if show is True:
@@ -2773,7 +2772,7 @@ class DetectionAnalysis(object):
             return None
 
         for candidate_index, yx_candidate_position in tqdm(enumerate(yx_candidate_positions)):
-            print("Running TRAP at candidate position: ", yx_candidate_position)
+            logger.info("Running TRAP at candidate position: %s", yx_candidate_position)
             candidate_spectrum = self.rereduce_single_position(
                 candidate_index=candidate_index,
                 yx_candidate_position=yx_candidate_position,
@@ -3066,9 +3065,7 @@ class DetectionAnalysis(object):
         try:
             database = Database()
         except:
-            print(
-                f"No initialized species database found in: {species_database_directory}"
-            )
+            logger.warning("No initialized species database found in: %s", species_database_directory)
             SpeciesInit()
             database = Database()
 
@@ -3714,16 +3711,18 @@ class DetectionAnalysis(object):
             
             # Check if candidates survived the second iteration validation
             if candidates_fit_final is None or len(candidates_fit_final) == 0:
-                print("Warning: No candidates survived second iteration validation")
-                print("This typically occurs when initial detections were false positives")
-                print("that did not meet the criteria when background statistics were corrected.")
+                logger.warning(
+                    "No candidates survived second iteration validation. This typically occurs "
+                    "when initial detections were false positives that did not meet the criteria "
+                    "when background statistics were corrected."
+                )
                 template.companion_table = None
                 template.validated_companion_table = None
                 template.validated_companion_table_short = None
                 template.detection_products = detection_products
                 return
             
-            print("Extracting candidate spectra.")
+            logger.info("Extracting candidate spectra.")
             candidate_spectra = self.extract_candidate_spectra(
                 yx_candidate_positions=candidates_fit_final["snr_image"][
                     ["y_relative", "x_relative"]
@@ -3993,7 +3992,7 @@ class DetectionAnalysis(object):
                 if not companion_table.empty:
                     combined_detection_products.append(companion_table)
             except FileNotFoundError:
-                print(f"{filename} not found.")
+                logger.warning("%s not found.", filename)
 
         if combined_detection_products:  # Check if list is not empty
             combined_companion_table = pd.concat(combined_detection_products, ignore_index=True)
@@ -4110,7 +4109,7 @@ class DetectionAnalysis(object):
                 index=False,
             )
         else:
-            print("No companion tables found.")
+            logger.warning("No companion tables found.")
 
 
     def detection_and_characterization(
@@ -4142,7 +4141,7 @@ class DetectionAnalysis(object):
             file_paths=self.file_paths
         )
 
-        print("Identifying and fitting potential candidates.")
+        logger.info("Identifying and fitting potential candidates.")
         candidates, candidates_fit = self.complete_candidate_table(
             wavelength_indices=None,
             candidate_threshold=candidate_threshold,
@@ -4157,7 +4156,7 @@ class DetectionAnalysis(object):
             plot_companions = False
         else:
             plot_companions = True
-            print("Extracting candidate spectra.")
+            logger.info("Extracting candidate spectra.")
             candidate_spectra = self.extract_candidate_spectra(
                 yx_candidate_positions=candidates_fit["snr_image"][
                     ["y_relative", "x_relative"]

--- a/src/trap/parameters.py
+++ b/src/trap/parameters.py
@@ -18,12 +18,15 @@ The legacy Reduction_parameters class is still available but deprecated.
 
 from __future__ import annotations
 
+import logging
 import multiprocessing
 from dataclasses import asdict, dataclass, field, replace
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 from astropy import units as u
+
+logger = logging.getLogger(__name__)
 
 
 class Instrument(object):
@@ -954,7 +957,7 @@ def build_runtime_state(
         guess_position_separation = np.sqrt(
             config.guess_position[0] ** 2 + config.guess_position[1] ** 2
         )
-        print("Adjusting outer bound to fit guess position")
+        logger.info("Adjusting outer bound to fit guess position")
         search_region_outer_bound = int(np.ceil(guess_position_separation) + 5)
 
     data_crop_size = config.data_crop_size
@@ -975,7 +978,7 @@ def build_runtime_state(
                 f"Data crop size {data_crop_size} is larger than input image "
                 f"size: {data_shape[-1]}"
             )
-        print(f"Auto crop size cropped data to: {data_crop_size}")
+        logger.info("Auto crop size cropped data to: %s", data_crop_size)
         yx_dim = (data_crop_size, data_crop_size)
     else:
         if config.search_region is None:

--- a/src/trap/pca_regression.py
+++ b/src/trap/pca_regression.py
@@ -5,6 +5,8 @@ Routines used in TRAP
          MPIA Heidelberg
 """
 
+import logging
+
 import matplotlib.pyplot as plt
 import numpy as np
 from astropy.stats import mad_std
@@ -13,6 +15,8 @@ from scipy.linalg import cholesky, solve_triangular, svd
 from sklearn import preprocessing
 
 from . import regressor_selection
+
+logger = logging.getLogger(__name__)
 
 # __all__ = ['matrix_scaling', 'compute_SVD', 'compute_V_inverse',
 #    'solve_linear_equation_simple', 'detect_bad_frames']
@@ -264,7 +268,7 @@ def remove_bad_frames(
         bad_frame_indices.append(bad_frame_indices_in_iteration)
         data = np.delete(data, bad_frame_indices_in_iteration, axis=0)
         if verbose:
-            print('Iteration: {} Bad frames: {}'.format(i, bad_frame_indices_in_iteration))
+            logger.debug("Iteration: %s Bad frames: %s", i, bad_frame_indices_in_iteration)
 
     return data, bad_frame_indices
 

--- a/src/trap/reduction_wrapper.py
+++ b/src/trap/reduction_wrapper.py
@@ -39,6 +39,7 @@ from trap.utils import (
 )
 
 logging.getLogger("ray").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 
@@ -339,7 +340,7 @@ def trap_one_position(
             if reduction_parameters.fit_planet:
                 result.compute_contrast_weighted_average(mask_outliers=True)
                 if reduction_parameters.verbose:
-                    print(result)
+                    logger.debug("%s", result)
             result.reduction_parameters = reduction_parameters
         results["spatial"] = result
 
@@ -439,7 +440,7 @@ def trap_one_position(
             if reduction_parameters.fit_planet:
                 result.compute_contrast_weighted_average(mask_outliers=True)
                 if reduction_parameters.verbose:
-                    print(result)
+                    logger.debug("%s", result)
             result.reduction_parameters = reduction_parameters
         results["temporal_plus_spatial"] = result
 
@@ -701,7 +702,7 @@ def run_trap_search(
             )
         )
     )
-    print("Number of positions: {}".format(len(relative_coords)))
+    logger.info("Number of positions: %d", len(relative_coords))
     ncpus = runtime.ncpus if runtime is not None else (reduction_parameters.ncpus or multiprocessing.cpu_count())
     if reduction_parameters.use_multiprocess:
         num_ticks = len(relative_coords)
@@ -729,9 +730,7 @@ def run_trap_search(
             max_iterations=50,
             rng=None,
         )
-        print(
-            "Number of positions per chunk: {}".format(len(relative_coords_regions[0]))
-        )
+        logger.debug("Number of positions per chunk: %d", len(relative_coords_regions[0]))
 
         a = datetime.datetime.now()
         data_id = ray.put(data)
@@ -823,8 +822,7 @@ def run_trap_search(
             del result
         b = datetime.datetime.now()
     c = b - a
-    print("Main reduction computation time:")
-    print(c)
+    logger.debug("Main reduction computation time: %s", c)
 
     if (
         not reduction_parameters.compute_residual_correlation
@@ -919,7 +917,7 @@ def multi_position_cross_validation(
     if amplitude_modulation is None:
         amplitude_modulation = np.ones(data.shape[0])
 
-    print("Number of positions: {}".format(len(relative_coords)))
+    logger.info("Number of positions: %d", len(relative_coords))
     if reduction_parameters.use_multiprocess:
         num_ticks = len(relative_coords)
         pb = ProgressBar(num_ticks)
@@ -996,8 +994,7 @@ def multi_position_cross_validation(
             results.append(result)
         b = datetime.datetime.now()
     c = b - a
-    print("Main reduction computation time:")
-    print(c)
+    logger.debug("Main reduction computation time: %s", c)
 
     return results
 
@@ -1304,9 +1301,7 @@ def run_complete_reduction(
                 xy_image_centers[..., 1]
             )
             max_shift = np.max([max_shift_x, max_shift_y]) * 2
-            print(
-                "The center varies by a maximum of in x or y: {}".format(max_shift / 2)
-            )
+            logger.debug("The center varies by a maximum of in x or y: %s", max_shift / 2)
         # print("Center variation: {}".format(np.std(amplitude_modulation_full, axis=0)))
 
     # Build runtime state (replaces all mutations of reduction_parameters)
@@ -1328,9 +1323,7 @@ def run_complete_reduction(
         amplitude_modulation_full = np.delete(
             amplitude_modulation_full, bad_frames, axis=1
         )
-        print(
-            "Amplitude variation: {}".format(np.std(amplitude_modulation_full, axis=1))
-        )
+        logger.debug("Amplitude variation: %s", np.std(amplitude_modulation_full, axis=1))
 
     # Configure number of principal components
 
@@ -1384,9 +1377,7 @@ def run_complete_reduction(
             logging_level=logging.WARNING)
 
     for comp_index, ncomp in enumerate(number_of_components):
-        print(
-            "Number of principal comp. used: {} of {}".format(ncomp, data_full.shape[1])
-        )
+        logger.debug("Number of principal comp. used: %s of %d", ncomp, data_full.shape[1])
 
         if reduction_parameters.reduce_single_position:
             wavelength_results = OrderedDict()
@@ -1401,11 +1392,7 @@ def run_complete_reduction(
             wavelength_index,
         ) in enumerate(wavelength_indices):
             wavelength = instrument.wavelengths[wavelength_index]
-            print(
-                "Lambda index: {} Wavelength: {:.3f}".format(
-                    wavelength_index, wavelength
-                )
-            )
+            logger.debug("Lambda index: %s Wavelength: %.3f", wavelength_index, wavelength)
             if prefix is None:
                 prefix = ""
             # Update per-iteration runtime state
@@ -1472,7 +1459,7 @@ def run_complete_reduction(
                     reduction_parameters.protection_angle,
                     reduction_parameters.spatial_components_fraction,
                 )
-            print(basename["temporal"])
+            logger.debug("%s", basename["temporal"])
 
             # Having all the different reductions in the output makes it easier to compare but also more complex to refactor
             # Since individual outputs cannot be checked for existence
@@ -1494,8 +1481,9 @@ def run_complete_reduction(
                 # If output file with basename already exists, skip reduction
                 if not overwrite and not reduction_parameters.reduce_single_position:
                     if os.path.exists(output_paths[key].detection_image):
-                        print(
-                            f"Reduction already exists for {output_paths[key].detection_image} - skipping."
+                        logger.info(
+                            "Reduction already exists for %s - skipping.",
+                            output_paths[key].detection_image,
                         )
                         return None
 
@@ -1673,17 +1661,12 @@ def run_complete_reduction(
             flux_psf_not_finite = np.any(~np.isfinite(flux_psf))
             yx_center_injection_not_finite = np.any(~np.isfinite(yx_center_injection))
             if flux_psf_not_finite:
-                print(
-                    "Skipping wavelength {}. NaNs detected in flux PSF.".format(
-                        wavelength_index
-                    )
-                )
+                logger.warning("Skipping wavelength %s. NaNs detected in flux PSF.", wavelength_index)
                 continue
             if yx_center_injection_not_finite:
-                print(
-                    "Skipping wavelength {}. NaNs detected in provided center position.".format(
-                        wavelength_index
-                    )
+                logger.warning(
+                    "Skipping wavelength %s. NaNs detected in provided center position.",
+                    wavelength_index,
                 )
                 continue
 
@@ -1714,7 +1697,7 @@ def run_complete_reduction(
                         verbose=False,
                     )
 
-            print("PSF Size: {}".format(runtime.reduction_mask_psf_size))
+            logger.debug("PSF Size: %s", runtime.reduction_mask_psf_size)
             if reduction_parameters.reduce_single_position:
                 results = trap_one_position(
                     reduction_parameters.guess_position,

--- a/src/trap/regression.py
+++ b/src/trap/regression.py
@@ -5,6 +5,7 @@ Routines used in TRAP
          MPIA Heidelberg
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -27,6 +28,8 @@ from trap.utils import (
     matern32_kernel,
     matern52_kernel,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class Result(object):
@@ -186,7 +189,7 @@ class Result(object):
         else:
             self.compute_good_residual_mask(sigma_for_outlier=sigma)
             self.compute_contrast_weighted_average(mask_outliers=True, use_signal_weighting=self.use_signal_weighting)
-        print(self.__str__())
+        logger.debug("%s", self)
 
     def compute_good_residual_mask(self,
                                    sigma=3, clip_median=True, clip_std=False,
@@ -197,8 +200,11 @@ class Result(object):
         number_of_nan_pixels = np.sum(mask_nans)
         number_of_pixels = self.residuals.shape[0]
         if number_of_nan_pixels > 0:
-            print(
-                f"Fraction of nan pixels: {number_of_nan_pixels / number_of_pixels}.\n Number of pixels: {number_of_pixels}")
+            logger.debug(
+                "Fraction of nan pixels: %s. Number of pixels: %d",
+                number_of_nan_pixels / number_of_pixels,
+                number_of_pixels,
+            )
         if clip_median:  # Clip pixels based on time-domain median
             mask.append(
                 sigma_clip(np.median(self.residuals, axis=1),
@@ -658,7 +664,7 @@ def run_trap_with_model_temporal(
             else:
                 regressor_pool_mask_global = regressor_pool_mask.copy()
             if verbose:
-                print("Number of reference pixel: {}".format(np.sum(regressor_pool_mask)))
+                logger.debug("Number of reference pixel: %d", np.sum(regressor_pool_mask))
 
             if not local_model:
                 if number_of_pca_regressors != 0:
@@ -702,7 +708,7 @@ def run_trap_with_model_temporal(
                     np.round(reduction_parameters.number_of_components_fraction * maximum_number_of_components))
                 if number_of_pca_regressors < 1:
                     number_of_pca_regressors = 1
-                print("Number of components used: {}".format(number_of_pca_regressors))
+                logger.debug("Number of components used: %s", number_of_pca_regressors)
 
         y = y[data_range_to_fit]
 
@@ -845,7 +851,7 @@ def run_trap_with_model_temporal(
 
         if reduction_parameters.plot_all_diagnostics and model is not None:
             if np.array_equal(yx_pixel, test_pixel):
-                print("Selected pixel: {}".format(yx_pixel))
+                logger.debug("Selected pixel: %s", yx_pixel)
                 mask_coordinates = np.argwhere(regressor_pool_mask)
 
                 plotting_tools.plot_scale(np.median(data, axis=0), yx_coords=mask_coordinates,
@@ -1136,7 +1142,7 @@ def run_trap_with_model_spatial(
         # flux_overlap_fraction = compute_flux_overlap(idx, model)
         # time_mask = flux_overlap_fraction < reduction_parameters.spatial_exclusion_flux_overlap
         if np.sum(time_mask) < 3:  # require at least 5 reference frames
-            print('Returning None for lack of frames')
+            logger.debug("Returning None for lack of frames")
             return None
 
         if training_data is None:
@@ -1449,7 +1455,7 @@ def run_trap_with_model_wavelength(
             else:
                 regressor_pool_mask_global = regressor_pool_mask.copy()
             if verbose:
-                print("Number of reference pixel: {}".format(np.sum(regressor_pool_mask)))
+                logger.debug("Number of reference pixel: %d", np.sum(regressor_pool_mask))
 
             if not local_model:
                 if number_of_pca_regressors != 0:
@@ -1492,7 +1498,7 @@ def run_trap_with_model_wavelength(
                     np.round(reduction_parameters.number_of_components_fraction * maximum_number_of_components))
                 if number_of_pca_regressors < 1:
                     number_of_pca_regressors = 1
-                print("Number of components used: {}".format(number_of_pca_regressors))
+                logger.debug("Number of components used: %s", number_of_pca_regressors)
 
         y = y[data_range_to_fit]
 
@@ -1557,7 +1563,7 @@ def run_trap_with_model_wavelength(
 
         if plot_all_diagnostics and model is not None:
             if np.array_equal(yx_pixel, test_pixel):
-                print("Selected pixel: {}".format(yx_pixel))
+                logger.debug("Selected pixel: %s", yx_pixel)
                 mask_coordinates = np.argwhere(regressor_pool_mask)
 
                 plotting_tools.plot_scale(np.median(data, axis=0), yx_coords=mask_coordinates,

--- a/src/trap/template.py
+++ b/src/trap/template.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import os
 
 import numpy as np
@@ -6,6 +7,8 @@ from astropy import units as u
 from species.phot.syn_phot import SyntheticPhotometry
 from species.plot.plot_spectrum import plot_spectrum
 from species.read.read_filter import ReadFilter
+
+logger = logging.getLogger(__name__)
 
 
 class SpectralTemplate(object):
@@ -235,7 +238,7 @@ class SpectralTemplate(object):
                 ylim = (np.min(modelbox.flux), np.max(modelbox.flux))
                 filters = None
 
-            print(filters)
+            logger.debug("%s", filters)
             plot_spectrum(
                 boxes=[modelbox],
                 filters=filters,

--- a/src/trap/utils.py
+++ b/src/trap/utils.py
@@ -5,6 +5,7 @@ Routines used in TRAP
          MPIA Heidelberg
 """
 
+import logging
 from asyncio import Event
 from typing import Tuple
 
@@ -22,6 +23,8 @@ from scipy.ndimage import spline_filter
 from tqdm import tqdm
 
 from trap import regressor_selection
+
+logger = logging.getLogger(__name__)
 
 
 @ray.remote
@@ -277,8 +280,7 @@ def resize_cube(arr, new_dim):
 def derotate_cube(flux_arr, pa, right_handed, verbose=False):
     for i in range(flux_arr.shape[0]):
         if verbose is True:
-            print("Derotating Spectral Channel: Frame: {:02d} by {:02.03f} degree.".format(
-                i + 1, pa[i]))
+            logger.debug("Derotating Spectral Channel: Frame: %02d by %02.03f degree.", i + 1, pa[i])
         flux_arr[i] = ndimage.rotate(flux_arr[i], pa[i], reshape=False)
 
     return flux_arr
@@ -304,7 +306,7 @@ def mask_cube(arr, dim, r_init=3, fwhm=5):
     assert len(np.asarray(arr).shape) == 4, "Function arr_resize expects a 4D data cube"
     for i in range(arr.shape[0]):
         for j in range(arr.shape[1]):
-            print("Masking Center of Channel {0}: Frame {1}".format(i + 1, j + 1))
+            logger.debug("Masking Center of Channel %d: Frame %d", i + 1, j + 1)
             arr[i, j] = mask_center(arr[i, j], dim, r_init, fwhm)
     return arr
 
@@ -314,12 +316,12 @@ def scale_images(arr, lam, newdim):
     """
     magnification = np.zeros_like(lam)
     flux = arr.copy()
-    print(arr.shape)
-    print(lam.shape)
+    logger.debug("%s", arr.shape)
+    logger.debug("%s", lam.shape)
     for i in range(lam.shape[0] - 1):
         magnification[i] = np.divide(lam[-1], lam[i])
         for j in range(arr.shape[1]):
-            print("Magnifing Channel {0}: Frame {1}".format(i + 1, j + 1))
+            logger.debug("Magnifing Channel %d: Frame %d", i + 1, j + 1)
             # Crop Image before saving into flux is necessary!
             flux[i, j] = resize_arr(ndimage.interpolation.zoom(
                 arr[i, j], float(magnification[i]), order=3), newdim)
@@ -331,11 +333,11 @@ def scale_images_sdi(arr, lam, newdim):
     """
     magnification = np.zeros_like(lam)
     flux = arr.copy()
-    print(arr.shape)
-    print(lam.shape)
+    logger.debug("%s", arr.shape)
+    logger.debug("%s", lam.shape)
     for i in range(lam.shape[0] - 1):
         magnification[i] = np.divide(lam[-1], lam[i])
-        print("Magnifing Channel {0}".format(i + 1))
+        logger.debug("Magnifing Channel %d", i + 1)
         # Crop Image before saving into flux is necessary!
         flux[i] = resize_arr(ndimage.interpolation.zoom(
             arr[i], float(magnification[i]), order=3), newdim)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,60 @@
+import importlib
+import logging
+import subprocess
+import sys
+
+import pytest
+
+
+def test_trap_root_logger_has_single_nullhandler():
+    import trap  # noqa: F401
+
+    root = logging.getLogger("trap")
+    null_handlers = [h for h in root.handlers if isinstance(h, logging.NullHandler)]
+    assert len(null_handlers) == 1
+    # Library must not force a level on itself.
+    assert root.level == logging.NOTSET
+
+
+def test_import_trap_prints_nothing_to_stdout():
+    result = subprocess.run(
+        [sys.executable, "-c", "import trap"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "trap.reduction_wrapper",
+        "trap.regression",
+        "trap.detection",
+        "trap.utils",
+        "trap.pca_regression",
+        "trap.parameters",
+        "trap.template",
+    ],
+)
+def test_module_defines_named_logger(module_name):
+    module = importlib.import_module(module_name)
+    assert isinstance(module.logger, logging.Logger)
+    assert module.logger.name == module_name
+
+
+def test_derotate_cube_emits_debug_record(caplog):
+    import numpy as np
+
+    from trap import utils
+
+    cube = np.zeros((2, 3, 3))
+    pa = np.array([10.0, 20.0])
+    with caplog.at_level(logging.DEBUG, logger="trap.utils"):
+        utils.derotate_cube(cube, pa, right_handed=True, verbose=True)
+
+    debug_records = [
+        r for r in caplog.records if r.name == "trap.utils" and r.levelno == logging.DEBUG
+    ]
+    assert debug_records, "expected a DEBUG record from trap.utils"
+    assert "Derotating" in debug_records[0].getMessage()


### PR DESCRIPTION
## Summary

Replaces `trap`'s library `print()` calls with standard-library `logging` — minimalist and Ray-safe — so a driver such as `spherical` can quiet routine output to warnings/errors and keep its outer progress bar intact.

- `src/trap/__init__.py` attaches a single `NullHandler` to the `trap` root logger and sets no level/handler. The library never configures logging for its callers.
- Every in-scope module gets `logger = logging.getLogger(__name__)`; live prints converted with lazy `%`-formatting per level map (stage milestones → `info`, timing/param/per-position detail → `debug`, recoverable degradations → `warning`). Docstring examples and commented prints untouched.
- **Ray safety:** the `@ray.remote` `trap_search_region` stays silent; `trap_one_position`'s verbose-gated diagnostics are now `debug`. No cross-process bridge, so nothing to make thread-unsafe.

Callers control verbosity via `logging.getLogger("trap").setLevel(...)`.

## Tests
- New `tests/test_logging.py`: NullHandler wiring, import-prints-nothing, per-module named-logger parametrization, and a `caplog` behavioral test — 10 pass.
- `ruff check src/` clean; `import trap` clean.

## Notes
- Pre-existing failures in the untracked scratch test `tests/test_empirical_correlation.py` (missing import) are unrelated to this change.
- The `docs/llm_reference/00_architecture.md` logging note is intentionally left untracked pending a separate decision.