### PR TITLE
WP1: Replace Ray with joblib/loky + memmap shared-array store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/) and [Sem
 
 ## [Unreleased]
 
+### Added
+- Optional coronagraph throughput correction: pass a `(separation_mas, throughput)`
+  table via `TrapReductionConfig.coronagraph_transmission` to attenuate the
+  forward model by the separation-dependent coronagraph transmission, correcting
+  underestimated contrasts at small separations (#31).
+
 ### Fixed
 - **Out-of-grid stellar parameters no longer abort template matching** – `add_default_templates` built the stellar template from the solar-only `bt-nextgen` grid but passed the requested `stellar_parameters` straight to `species`' `get_model`, so a sub-solar `[Fe/H]` (or an out-of-range Teff/log g) raised `ValueError: … smaller than the lower boundary of the model grid`. Values are now clamped to the grid boundaries (via `ReadModel.get_bounds()`) before `get_model`, snapping to the nearest edge with a `warnings.warn`, so any caller's stellar parameters degrade gracefully instead of crashing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/) and [Sem
   table via `TrapReductionConfig.coronagraph_transmission` to attenuate the
   forward model by the separation-dependent coronagraph transmission, correcting
   underestimated contrasts at small separations (#31).
+- **Shared-array store** (`trap.shared_arrays`) – large input arrays are dumped
+  once as `.npy` files to a scratch directory and worker processes memmap them
+  read-only, so the OS page cache provides a single shared in-RAM copy per node.
+  The scratch directory is configurable via `TrapReductionConfig.scratch_dir` /
+  `TrapResources.scratch_dir` and defaults to `/dev/shm` when present with
+  sufficient headroom (cluster nodes), otherwise the system temp directory
+  (see `trap.parameters.resolve_scratch_dir`).
+- Serial-vs-parallel equivalence test on a synthetic cube
+  (`tests/test_parallel_equivalence.py`) plus unit tests for the shared-array
+  store (`tests/test_shared_arrays.py`).
+
+### Changed
+- **Ray removed; multiprocessing now uses joblib/loky** – `run_trap_search` and
+  `multi_position_cross_validation` dispatch position chunks through
+  `joblib.Parallel` (loky backend) instead of Ray remote functions. Results are
+  identical to the serial path; single-wavelength reductions are unchanged.
+  Startup time, memory reservation and dependency footprint shrink, worker
+  logs/exceptions now surface on the driver, and one code path serves laptop
+  and cluster (multi-node scaling via scheduler job arrays over
+  wavelengths/epochs). BLAS threads in workers are capped to 1, matching Ray's
+  previous implicit behavior.
+- `run_complete_reduction` dumps the preprocessed per-wavelength data (and
+  inverse variance) to the shared-array store once, before the
+  component/wavelength loops, instead of re-transferring the cube to workers
+  for every component fraction. Position chunking raised from `2 × ncpus` to
+  `8 × ncpus` to reduce idle tails.
+- Progress reporting is now a driver-side `tqdm` bar ticking per completed
+  chunk; the Ray-based `ProgressBarActor`/`ProgressBar` in `trap.utils` were
+  removed, along with the no-op `==` statements that belonged to them
+  (roadmap item 5 / improvement note 7).
+
+### Removed
+- Dependency on `ray[default]`; `joblib` added instead.
 
 ### Fixed
 - **Out-of-grid stellar parameters no longer abort template matching** – `add_default_templates` built the stellar template from the solar-only `bt-nextgen` grid but passed the requested `stellar_parameters` straight to `species`' `get_model`, so a sub-solar `[Fe/H]` (or an out-of-range Teff/log g) raised `ValueError: … smaller than the lower boundary of the model grid`. Values are now clamped to the grid boundaries (via `ReadModel.get_bounds()`) before `get_model`, snapping to the nearest edge with a `warnings.warn`, so any caller's stellar parameters degrade gracefully instead of crashing.

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -238,6 +238,37 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Optional: coronagraph throughput correction (issue #31) --------------\n",
+    "# Close to the star the coronagraph attenuates real planet flux. Without this\n",
+    "# correction the extracted contrast at small separations is underestimated.\n",
+    "# Provide a table of separation (in mas) vs. throughput (in [0, 1], reaching 1\n",
+    "# beyond the coronagraph inner working angle). TRAP converts the mas axis to\n",
+    "# pixels internally using the instrument pixel scale, looks up the throughput\n",
+    "# at each search position, and scales the injected forward model accordingly.\n",
+    "# Left as None (the default), no correction is applied.\n",
+    "#\n",
+    "# The table can be an (N, 2) array of [separation_mas, throughput] rows, or a\n",
+    "# (separation_mas, throughput) tuple of 1-D arrays. Below the smallest tabulated\n",
+    "# separation the innermost value is used; beyond the largest it is treated as 1.\n",
+    "# Since TrapReductionConfig is frozen, use merge() to attach it:\n",
+    "#\n",
+    "# coronagraph_transmission = np.array([\n",
+    "#     [0.,   0.00],\n",
+    "#     [100., 0.30],\n",
+    "#     [200., 0.70],\n",
+    "#     [300., 0.95],\n",
+    "#     [400., 1.00],\n",
+    "# ])\n",
+    "# reduction_config = reduction_config.merge(\n",
+    "#     coronagraph_transmission=coronagraph_transmission)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,11 +23,11 @@ bottleneck = "*"
 natsort = "*"
 dill = "*"
 cython = "*"
+joblib = "*"
 
 # Editable install of the package itself
 [pypi-dependencies]
 trap = { path = ".", editable = true }
-ray = { version = ">=2.47.1", extras = ["default"] }
 species = { git = "https://github.com/tomasstolker/species" }
 
 # ──────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "photutils",
     "seaborn",
     "tqdm",
-    "ray[default]>=2.47.1",
+    "joblib",
     "bottleneck",
     "natsort",
     "species@git+https://github.com/tomasstolker/species", 

--- a/src/trap/detection.py
+++ b/src/trap/detection.py
@@ -70,7 +70,7 @@ def make_radial_profile(
 
     Parameters:
     - data (ndarray): The 2D data array.
-    - radial_bounds (list, optional): The radial bounds of the profile. If not provided, the bounds are determined based on the size of the data array.
+    - radial_bounds (tuple, optional): The radial bounds of the profile. If not provided, the bounds are determined based on the size of the data array.
     - bin_width (float, optional): The width of each radial bin.
     - operation (str, optional): The operation to be applied to the data within each bin. Options are "mad_std", "median", "mean", "min", "std", and "percentiles".
     - yx_center (tuple, optional): The center coordinates of the data array. If not provided, the center is assumed to be the center of the data array.
@@ -89,7 +89,7 @@ def make_radial_profile(
 
     if radial_bounds is None:
         separation_max = data.shape[-1] // 2 * np.sqrt(2)
-        radial_bounds = [1, int(separation_max)]
+        radial_bounds = (1, int(separation_max))
 
     if yx_center is None:
         yx_center = (data.shape[-2] // 2.0, data.shape[-1] // 2.0)
@@ -117,7 +117,7 @@ def make_radial_profile(
     if non_zero_separation > radial_bounds[0] + 13:
         non_zero_separation = 0
 
-    for _, separation in enumerate(range(radial_bounds[0], radial_bounds[1])):
+    for separation in range(radial_bounds[0], radial_bounds[1]):
         if separation < non_zero_separation:
             if operation == "percentiles":
                 values.append(np.ones(7) * np.nan)
@@ -208,7 +208,7 @@ def make_contrast_curve(
 
     if radial_bounds is None:
         separation_max = detection_image.shape[-1] // 2 * np.sqrt(2)
-        radial_bounds = [1, int(separation_max)]
+        radial_bounds = (1, int(separation_max))
 
     if yx_known_companion_position is not None:
         yx_known_companion_position = np.array(yx_known_companion_position)
@@ -1079,6 +1079,23 @@ def fit_2d_gaussian(
     else:
         cy, cx = yx_position
     cutout = Cutout2D(image, (cx, cy), box_size)
+
+    if np.all(np.isnan(cutout.data)):
+        # The cutout contains only NaNs.
+        # This likely has happened because the cutout of the
+        # normalized_detection_image contains only NaNs, which
+        # is a result of make_radial_profile creating a central
+        # mask of NaNs. This can happen with a candidate close
+        # to the search_region_inner_bound.
+
+        raise RuntimeError(
+            f"The cutout image at position (y, x) = ({cy}, {cx}) "
+            "contains only NaNs. The issue might be caused by "
+            "make_radial_profile that is used for "
+            "normalized_detection_image. Perhaps there is a "
+            "candidate too close to the search_region_inner_bound? "
+        )
+
     # stamp = image[cy - box_size:cy + box_size, cx - box_size:cx + box_size].copy()
     xx, yy = np.meshgrid(np.arange(box_size), np.arange(box_size))
     yx_position_cutout = np.unravel_index(np.nanargmax(cutout.data), cutout.shape)

--- a/src/trap/makesource.py
+++ b/src/trap/makesource.py
@@ -4,6 +4,8 @@ Routines used in TRAP
 @author: Tim Brandt, Matthias Samland
 """
 
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
 from astropy.nddata import Cutout2D
@@ -364,3 +366,79 @@ def extract_stamps(flux_arr, pos, pa, stamp_size, image_center=None,
 
     stamps = np.array(stamps)
     return stamps, shifts
+
+
+def coronagraph_transmission_to_pixels(transmission, mas_per_pixel):
+    """Convert a coronagraph throughput table's separation axis to pixels.
+
+    Parameters
+    ----------
+    transmission : array_like
+        Either an ``(N, 2)`` array of ``[separation_mas, throughput]`` rows, or
+        a ``(separation_mas, throughput)`` tuple of 1-D arrays. Throughput must
+        lie in ``[0, 1]``.
+    mas_per_pixel : float
+        Instrument plate scale in milliarcseconds per pixel.
+
+    Returns
+    -------
+    numpy.ndarray
+        Sorted ``(N, 2)`` float array of ``[separation_pixels, throughput]``.
+    """
+    if isinstance(transmission, tuple) and len(transmission) == 2:
+        separation_mas = np.asarray(transmission[0], dtype=float)
+        throughput = np.asarray(transmission[1], dtype=float)
+    else:
+        transmission = np.asarray(transmission, dtype=float)
+        if transmission.ndim != 2 or transmission.shape[1] != 2:
+            raise ValueError(
+                "coronagraph_transmission must be an (N, 2) array or a "
+                "(separation_mas, throughput) tuple."
+            )
+        separation_mas = transmission[:, 0]
+        throughput = transmission[:, 1]
+
+    if np.any(throughput < 0.0) or np.any(throughput > 1.0):
+        warnings.warn(
+            "Coronagraph throughput values outside [0, 1] were clipped.",
+            stacklevel=2,
+        )
+    throughput = np.clip(throughput, 0.0, 1.0)
+
+    order = np.argsort(separation_mas)
+    separation_pix = separation_mas[order] / mas_per_pixel
+    throughput = throughput[order]
+
+    if not np.isclose(throughput[-1], 1.0):
+        warnings.warn(
+            "Largest-separation coronagraph throughput is not 1.0; separations "
+            "beyond the table are treated as fully transmitting (1.0).",
+            stacklevel=2,
+        )
+
+    return np.column_stack((separation_pix, throughput))
+
+
+def coronagraph_throughput_factor(separation_pix, transmission_pix):
+    """Interpolate the coronagraph throughput at a given separation in pixels.
+
+    Below the smallest tabulated separation the innermost value is used; beyond
+    the largest tabulated separation the throughput is 1.0.
+
+    Parameters
+    ----------
+    separation_pix : float
+        Separation of the candidate from the star in pixels.
+    transmission_pix : numpy.ndarray
+        Sorted ``(N, 2)`` array of ``[separation_pixels, throughput]``.
+
+    Returns
+    -------
+    float
+        Throughput scaling factor in ``[0, 1]``.
+    """
+    separation = transmission_pix[:, 0]
+    throughput = transmission_pix[:, 1]
+    return float(
+        np.interp(separation_pix, separation, throughput, left=throughput[0], right=1.0)
+    )

--- a/src/trap/parameters.py
+++ b/src/trap/parameters.py
@@ -763,6 +763,7 @@ class TrapReductionConfig:
     threshold_pixel_by_contribution: float = 0.0
     target_pix_mask_radius: Optional[float] = None
     use_relative_position: bool = False
+    coronagraph_transmission: Optional[Any] = None
     
     # Regressor selection
     annulus_width: int = 5
@@ -805,7 +806,8 @@ class TrapReductionConfig:
             stacklevel=2,
         )
         params_dict = asdict(self)
-        
+        params_dict.pop("coronagraph_transmission", None)
+
         # Filter out None values, but keep explicit None defaults where needed
         filtered_params = {}
         for k, v in params_dict.items():
@@ -841,6 +843,7 @@ class ReductionRuntimeState:
     data_crop_size: Optional[int] = None
     search_region: Optional[np.ndarray] = None       # binary mask
     ncpus: int = 4
+    coronagraph_transmission_pix: Optional[np.ndarray] = None
 
     # --- Category C: per iteration (wavelength x component) ---
     number_of_pca_regressors: int = 20
@@ -874,6 +877,7 @@ def build_runtime_state(
     stamp_sizes: np.ndarray,
     stamp_sizes_reduction: np.ndarray,
     max_shift: float,
+    mas_per_pixel: Optional[float] = None,
 ) -> ReductionRuntimeState:
     """Compute all derived values from user config + data properties.
 
@@ -899,6 +903,19 @@ def build_runtime_state(
     ReductionRuntimeState
     """
     from trap import regressor_selection  # local import to avoid circular
+
+    coronagraph_transmission_pix = None
+    transmission = getattr(config, "coronagraph_transmission", None)
+    if transmission is not None:
+        if mas_per_pixel is None:
+            raise ValueError(
+                "mas_per_pixel is required to use coronagraph_transmission."
+            )
+        from trap.makesource import coronagraph_transmission_to_pixels
+
+        coronagraph_transmission_pix = coronagraph_transmission_to_pixels(
+            transmission, mas_per_pixel
+        )
 
     # --- Category A: normalize inputs ---
     yx_anamorphism = np.array(config.yx_anamorphism)
@@ -1011,6 +1028,7 @@ def build_runtime_state(
         data_crop_size=data_crop_size,
         search_region=search_region,
         ncpus=ncpus,
+        coronagraph_transmission_pix=coronagraph_transmission_pix,
         # Category C: initial values (will be overwritten by for_iteration)
         number_of_pca_regressors=config.number_of_pca_regressors,
         temporal_components_fraction=0.0,

--- a/src/trap/parameters.py
+++ b/src/trap/parameters.py
@@ -19,7 +19,11 @@ The legacy Reduction_parameters class is still available but deprecated.
 from __future__ import annotations
 
 import multiprocessing
+import os
+import shutil
+import tempfile
 from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
@@ -731,6 +735,7 @@ class TrapReductionConfig:
     # Processing parameters
     use_multiprocess: bool = True
     ncpus: int = 4
+    scratch_dir: Optional[Path] = None
     prefix: str = ''
     result_folder: str = './'
     
@@ -1078,13 +1083,48 @@ class TrapResources:
     """Resource management for TRAP processing."""
     ncpu_reduction: int = 1
     ncpu_detection: int = 1
+    scratch_dir: Optional[Path] = None
 
     def apply(self, reduction_config: TrapReductionConfig) -> TrapReductionConfig:
         """Apply resource settings to reduction configuration.
 
         Returns a new config with ncpus set (frozen config cannot be mutated).
         """
-        return reduction_config.merge(ncpus=self.ncpu_reduction)
+        return reduction_config.merge(
+            ncpus=self.ncpu_reduction, scratch_dir=self.scratch_dir
+        )
+
+
+def resolve_scratch_dir(scratch_dir=None, required_bytes=None):
+    """Resolve the directory used for the shared-array store.
+
+    Resolution order: an explicit ``scratch_dir`` always wins; otherwise
+    ``/dev/shm`` is used if it exists and has headroom for the estimated
+    store size; otherwise ``tempfile.gettempdir()``.
+
+    Parameters
+    ----------
+    scratch_dir : str or Path, optional
+        Explicit scratch directory. Used as-is if given.
+    required_bytes : int, optional
+        Estimated size of the store. Used to check ``/dev/shm`` headroom;
+        if None, ``/dev/shm`` is used whenever it exists.
+
+    Returns
+    -------
+    Path
+        Directory in which to create the shared-array store.
+    """
+    if scratch_dir is not None:
+        return Path(scratch_dir)
+    shm = Path("/dev/shm")
+    if shm.is_dir() and os.access(shm, os.W_OK):
+        if required_bytes is None:
+            return shm
+        # Require 20% headroom over the estimated store size.
+        if shutil.disk_usage(shm).free > required_bytes * 1.2:
+            return shm
+    return Path(tempfile.gettempdir())
 
 
 # -------- wavelength and processing parameters ------------------------------

--- a/src/trap/reduction_wrapper.py
+++ b/src/trap/reduction_wrapper.py
@@ -12,6 +12,7 @@ import multiprocessing
 import os
 from collections import OrderedDict
 
+import astropy.units as u
 import numpy as np
 import ray
 from astropy.io import fits
@@ -129,6 +130,13 @@ def trap_one_position(
     planet_absolute_yx_pos = image_coordinates.relative_yx_to_absolute_yx(
         signal_position, yx_center
     )
+
+    if runtime.coronagraph_transmission_pix is not None:
+        separation_pix = np.hypot(signal_position[0], signal_position[1])
+        # amplitude_modulation is shared read-only via ray.put: copy, never mutate.
+        amplitude_modulation = amplitude_modulation * makesource.coronagraph_throughput_factor(
+            separation_pix, runtime.coronagraph_transmission_pix
+        )
 
     injected_model_cube = np.zeros_like(data)
     injected_model_cube = makesource.inject_model_into_data(
@@ -1316,6 +1324,7 @@ def run_complete_reduction(
         stamp_sizes=stamp_sizes,
         stamp_sizes_reduction=stamp_sizes_reduction,
         max_shift=max_shift,
+        mas_per_pixel=(1 * u.pixel).to(u.mas, equivalencies=instrument.pixel_scale).value,
     )
     data_crop_size = runtime.data_crop_size
 

--- a/src/trap/reduction_wrapper.py
+++ b/src/trap/reduction_wrapper.py
@@ -7,16 +7,15 @@ Routines used in TRAP
 
 import dataclasses
 import datetime
-import logging
 import multiprocessing
 import os
 from collections import OrderedDict
 
 import astropy.units as u
 import numpy as np
-import ray
 from astropy.io import fits
 from astropy.stats import mad_std
+from joblib import Parallel, delayed, parallel_config
 from tqdm.auto import tqdm
 
 from trap import (
@@ -24,13 +23,14 @@ from trap import (
     makesource,
     regression,
     regressor_selection,
+    shared_arrays,
 )
 from trap.parameters import (
     _to_reduction_config,
     build_runtime_state,
 )
+from trap.shared_arrays import SharedArrayRef, SharedArrayStore
 from trap.utils import (
-    ProgressBar,
     crop_box_from_3D_cube,
     crop_box_from_image,
     determine_psf_stampsizes,
@@ -39,11 +39,7 @@ from trap.utils import (
     shuffle_and_equalize_relative_positions,
 )
 
-logging.getLogger("ray").setLevel(logging.WARNING)
 
-
-
-# @ ray.remote
 def trap_one_position(
     guess_position,
     data,
@@ -133,7 +129,7 @@ def trap_one_position(
 
     if runtime.coronagraph_transmission_pix is not None:
         separation_pix = np.hypot(signal_position[0], signal_position[1])
-        # amplitude_modulation is shared read-only via ray.put: copy, never mutate.
+        # amplitude_modulation is shared read-only across positions: copy, never mutate.
         amplitude_modulation = amplitude_modulation * makesource.coronagraph_throughput_factor(
             separation_pix, runtime.coronagraph_transmission_pix
         )
@@ -616,12 +612,23 @@ def run_trap_search(
             6) Deviation from `true_contrast` in sigma
     """
 
-    data = data.astype("float64")
+    # `data`/`inverse_variance` may be shared-store references (dumped as
+    # float64); resolve to read-only memmap views for driver-side use.
+    data_ref = data if isinstance(data, SharedArrayRef) else None
+    inverse_variance_ref = (
+        inverse_variance if isinstance(inverse_variance, SharedArrayRef) else None
+    )
+    data = shared_arrays.resolve(data)
+    inverse_variance = shared_arrays.resolve(inverse_variance)
+
+    data = data.astype("float64", copy=data_ref is None)
     flux_psf = flux_psf.astype("float64")
     pa = pa.astype("float64")
 
     if inverse_variance is not None:
-        inverse_variance = inverse_variance.astype("float64")
+        inverse_variance = inverse_variance.astype(
+            "float64", copy=inverse_variance_ref is None
+        )
 
     oversampling = reduction_parameters.oversampling
     yx_dim = (data.shape[-2], data.shape[-1])
@@ -711,17 +718,10 @@ def run_trap_search(
     )
     print("Number of positions: {}".format(len(relative_coords)))
     ncpus = runtime.ncpus if runtime is not None else (reduction_parameters.ncpus or multiprocessing.cpu_count())
+    ncpus = min(ncpus, multiprocessing.cpu_count())
     if reduction_parameters.use_multiprocess:
-        num_ticks = len(relative_coords)
-        if use_progress_bar:
-            pb = ProgressBar(num_ticks)
-            actor = pb.actor
-        else:
-            pb = None
-            actor = None
-
         # Use more chunks than CPUs to prevent long idle time in case one job finishes quicker
-        number_of_chunks = round(ncpus * 2)
+        number_of_chunks = round(ncpus * 8)
 
         (
             search_coordinates,
@@ -742,41 +742,54 @@ def run_trap_search(
         )
 
         a = datetime.datetime.now()
-        data_id = ray.put(data)
-        inverse_variance_id = ray.put(inverse_variance)
-        flux_psf_id = ray.put(flux_psf)
-        pa_id = ray.put(pa)
-        known_companion_mask_id = ray.put(known_companion_mask)
-        amplitude_modulation_id = ray.put(amplitude_modulation)
-        bad_pixel_mask_id = ray.put(bad_pixel_mask)
-        contrast_map_id = ray.put(contrast_map)
-        result_ids = []
-        for region in relative_coords_regions:
-            result_ids.append(
-                trap_search_region.remote(
-                    region,
-                    data=data_id,
-                    inverse_variance=inverse_variance_id,
-                    flux_psf=flux_psf_id,
-                    pa=pa_id,
-                    reduction_parameters=reduction_parameters,
-                    runtime=runtime,
-                    known_companion_mask=known_companion_mask_id,
-                    bad_pixel_mask=bad_pixel_mask_id,
-                    yx_center=yx_center,
-                    yx_center_injection=yx_center_injection,
-                    amplitude_modulation=amplitude_modulation_id,
-                    contrast_map=contrast_map_id,
-                    readnoise=readnoise,
-                    pba=actor,
-                )
+        own_store = None
+        if data_ref is None:
+            # Standalone call without a pre-dumped store: dump the large
+            # arrays here so workers memmap them instead of unpickling copies.
+            required_bytes = data.nbytes
+            if inverse_variance is not None:
+                required_bytes += inverse_variance.nbytes
+            own_store = SharedArrayStore(
+                scratch_dir=getattr(reduction_parameters, "scratch_dir", None),
+                required_bytes=required_bytes,
             )
-        if pb is not None:
-            pb.print_until_done()
-        results = ray.get(result_ids)
-        if actor is not None:
-            results == list(range(num_ticks))
-            num_ticks == ray.get(actor.get_counter.remote())
+            data_ref = own_store.dump("data", data)
+            if inverse_variance is not None:
+                inverse_variance_ref = own_store.dump(
+                    "inverse_variance", inverse_variance
+                )
+        try:
+            with parallel_config(backend="loky", inner_max_num_threads=1):
+                result_generator = Parallel(n_jobs=ncpus, return_as="generator")(
+                    delayed(trap_search_region)(
+                        region,
+                        data=data_ref,
+                        inverse_variance=inverse_variance_ref,
+                        flux_psf=flux_psf,
+                        pa=pa,
+                        reduction_parameters=reduction_parameters,
+                        runtime=runtime,
+                        known_companion_mask=known_companion_mask,
+                        bad_pixel_mask=bad_pixel_mask,
+                        yx_center=yx_center,
+                        yx_center_injection=yx_center_injection,
+                        amplitude_modulation=amplitude_modulation,
+                        contrast_map=contrast_map,
+                        readnoise=readnoise,
+                    )
+                    for region in relative_coords_regions
+                )
+                results = list(
+                    tqdm(
+                        result_generator,
+                        total=len(relative_coords_regions),
+                        unit="chunk",
+                        disable=not use_progress_bar,
+                    )
+                )
+        finally:
+            if own_store is not None:
+                own_store.cleanup()
         results = [item for sublist in results for item in sublist]
 
         for idx, result in enumerate(results):
@@ -913,12 +926,23 @@ def multi_position_cross_validation(
             6) Deviation from `true_contrast` in sigma
     """
 
-    data = data.astype("float64")
+    # `data`/`inverse_variance` may be shared-store references (dumped as
+    # float64); resolve to read-only memmap views for driver-side use.
+    data_ref = data if isinstance(data, SharedArrayRef) else None
+    inverse_variance_ref = (
+        inverse_variance if isinstance(inverse_variance, SharedArrayRef) else None
+    )
+    data = shared_arrays.resolve(data)
+    inverse_variance = shared_arrays.resolve(inverse_variance)
+
+    data = data.astype("float64", copy=data_ref is None)
     flux_psf = flux_psf.astype("float64")
     pa = pa.astype("float64")
 
     if inverse_variance is not None:
-        inverse_variance = inverse_variance.astype("float64")
+        inverse_variance = inverse_variance.astype(
+            "float64", copy=inverse_variance_ref is None
+        )
 
     yx_dim = (data.shape[-2], data.shape[-1])
     if yx_center is None:
@@ -928,48 +952,52 @@ def multi_position_cross_validation(
         amplitude_modulation = np.ones(data.shape[0])
 
     print("Number of positions: {}".format(len(relative_coords)))
+    ncpus = runtime.ncpus if runtime is not None else (reduction_parameters.ncpus or multiprocessing.cpu_count())
+    ncpus = min(ncpus, multiprocessing.cpu_count())
     if reduction_parameters.use_multiprocess:
-        num_ticks = len(relative_coords)
-        pb = ProgressBar(num_ticks)
-        actor = pb.actor
-
         a = datetime.datetime.now()
-        data_id = ray.put(data)
-        inverse_variance_id = ray.put(inverse_variance)
-        flux_psf_id = ray.put(flux_psf)
-        pa_id = ray.put(pa)
-        known_companion_mask_id = ray.put(known_companion_mask)
-        amplitude_modulation_id = ray.put(amplitude_modulation)
-        bad_pixel_mask_id = ray.put(bad_pixel_mask)
-        contrast_map_id = ray.put(contrast_map)
-        result_ids = []
-
-        for coords in relative_coords:
-            result_ids.append(
-                trap_search_region.remote(
-                    coords,
-                    data=data_id,
-                    inverse_variance=inverse_variance_id,
-                    flux_psf=flux_psf_id,
-                    pa=pa_id,
-                    reduction_parameters=reduction_parameters,
-                    runtime=runtime,
-                    known_companion_mask=known_companion_mask_id,
-                    bad_pixel_mask=bad_pixel_mask_id,
-                    yx_center=yx_center,
-                    yx_center_injection=yx_center_injection,
-                    amplitude_modulation=amplitude_modulation_id,
-                    contrast_map=contrast_map_id,
-                    readnoise=readnoise,
-                    cross_validation=True,
-                    pba=actor,
-                )
+        own_store = None
+        if data_ref is None:
+            # Standalone call without a pre-dumped store: dump the large
+            # arrays here so workers memmap them instead of unpickling copies.
+            required_bytes = data.nbytes
+            if inverse_variance is not None:
+                required_bytes += inverse_variance.nbytes
+            own_store = SharedArrayStore(
+                scratch_dir=getattr(reduction_parameters, "scratch_dir", None),
+                required_bytes=required_bytes,
             )
-
-        pb.print_until_done()
-        results = ray.get(result_ids)
-        results == list(range(num_ticks))
-        num_ticks == ray.get(actor.get_counter.remote())
+            data_ref = own_store.dump("data", data)
+            if inverse_variance is not None:
+                inverse_variance_ref = own_store.dump(
+                    "inverse_variance", inverse_variance
+                )
+        try:
+            with parallel_config(backend="loky", inner_max_num_threads=1):
+                result_generator = Parallel(n_jobs=ncpus, return_as="generator")(
+                    delayed(trap_search_region)(
+                        coords,
+                        data=data_ref,
+                        inverse_variance=inverse_variance_ref,
+                        flux_psf=flux_psf,
+                        pa=pa,
+                        reduction_parameters=reduction_parameters,
+                        runtime=runtime,
+                        known_companion_mask=known_companion_mask,
+                        bad_pixel_mask=bad_pixel_mask,
+                        yx_center=yx_center,
+                        yx_center_injection=yx_center_injection,
+                        amplitude_modulation=amplitude_modulation,
+                        contrast_map=contrast_map,
+                        readnoise=readnoise,
+                        cross_validation=True,
+                    )
+                    for coords in relative_coords
+                )
+                results = list(tqdm(result_generator, total=len(relative_coords)))
+        finally:
+            if own_store is not None:
+                own_store.cleanup()
         results = [item for sublist in results for item in sublist]
 
         b = datetime.datetime.now()
@@ -1010,7 +1038,6 @@ def multi_position_cross_validation(
     return results
 
 
-@ray.remote
 def trap_search_region(
     relative_coords,
     data,
@@ -1028,7 +1055,6 @@ def trap_search_region(
     contrast_map=None,
     readnoise=0.0,
     cross_validation=False,
-    pba=None,
 ):
     """Iterates TRAP over grid of positions given by the boolean mask
     `search_region` in the `reduction_parameters` object.
@@ -1082,6 +1108,11 @@ def trap_search_region(
             6) Deviation from `true_contrast` in sigma
     """
 
+    # In worker processes the large arrays arrive as shared-store references;
+    # resolve them to read-only memmaps (plain arrays pass through).
+    data = shared_arrays.resolve(data)
+    inverse_variance = shared_arrays.resolve(inverse_variance)
+
     sub_region_results = []
     for idx, coords in enumerate(relative_coords):
         result = trap_one_position(
@@ -1102,8 +1133,6 @@ def trap_search_region(
             cross_validation=cross_validation,
         )
         sub_region_results.append(result)
-        if pba is not None:
-            pba.update.remote(1)
     return sub_region_results
 
 
@@ -1117,6 +1146,132 @@ def make_reduction_header(
     yx_known_companion_position,
 ):
     raise NotImplementedError()
+
+
+def _wavelength_geometry(
+    wavelength_index,
+    data_shape,
+    data_crop_size,
+    yx_center_full,
+    yx_center_injection_full,
+):
+    """Output-frame center and per-frame injection centers for one wavelength.
+
+    Single source of truth for the geometry used both when filling the
+    shared-array store and inside the reduction loops of
+    `run_complete_reduction`.
+    """
+    # This block defines yx_center which gives the center of the output file
+    # based on cropping or no cropping
+    if yx_center_full is None:
+        if data_crop_size is None:
+            yx_center = np.array((data_shape[-2] // 2.0, data_shape[-1] // 2.0))
+        else:
+            yx_center = np.array((data_crop_size // 2.0, data_crop_size // 2.0))
+    else:
+        if data_crop_size is None:
+            yx_center = np.array(yx_center_full[wavelength_index])
+        else:
+            yx_center = np.array((data_crop_size // 2.0, data_crop_size // 2.0))
+
+    yx_center_injection = yx_center
+    if yx_center_injection_full is not None:
+        try:
+            if yx_center_injection_full.ndim == 3:
+                if data_crop_size is None:
+                    yx_center_injection = yx_center_injection_full[
+                        wavelength_index, :
+                    ]
+                else:
+                    # Image centers in cropped frame
+                    yx_center_injection = (
+                        yx_center_injection_full[wavelength_index, :]
+                        - np.round(yx_center_full[wavelength_index])
+                        + yx_center
+                    )
+                    # Non-rounded image center in cropped frame
+                    yx_center = np.nanmedian(yx_center_injection, axis=0)
+        except AttributeError:
+            pass
+    return yx_center, yx_center_injection
+
+
+def _prepare_wavelength_slice(
+    wavelength_index,
+    data_full,
+    inverse_variance_full,
+    flux_psf,
+    pa,
+    reduction_parameters,
+    runtime,
+    data_crop_size,
+    yx_center_full,
+    yx_center_injection,
+    amplitude_modulation,
+):
+    """Crop the data (and inverse variance) for one wavelength and remove
+    known companions if configured.
+
+    Single source of truth for the per-wavelength data consumed by the
+    reduction: used to fill the shared-array store before the loops of
+    `run_complete_reduction` (parallel path) and inside the loops (serial
+    and single-position paths).
+    """
+    if reduction_parameters.inject_fake:
+        # Return copy of data when injecting fake to not contaminate data
+        if data_crop_size is not None:
+            data = crop_box_from_3D_cube(
+                data_full[wavelength_index],
+                data_crop_size,
+                center_yx=np.round(yx_center_full[wavelength_index]),
+            ).copy()
+        else:
+            data = data_full[wavelength_index].copy()
+    else:
+        if data_crop_size is not None:
+            data = crop_box_from_3D_cube(
+                data_full[wavelength_index],
+                data_crop_size,
+                center_yx=np.round(yx_center_full[wavelength_index]),
+            )
+        else:
+            data = data_full[wavelength_index]
+
+    if inverse_variance_full is not None:
+        inverse_variance = crop_box_from_3D_cube(
+            inverse_variance_full[wavelength_index],
+            data_crop_size,
+            center_yx=np.round(yx_center_full[wavelength_index]),
+        ).copy()
+    else:
+        inverse_variance = None
+
+    if reduction_parameters.remove_known_companions:
+        # NOTE: This currently doesn't remove photon noise from variance map
+        # NOTE: Should change to faster implementation of `inject_model_into_data`
+
+        for companion_index, kc_contrast in enumerate(
+            runtime.known_companion_contrast[wavelength_index]
+        ):
+            # NOTE: Check format of known_companion_contrast and amplitude_modulation
+            kc_contrast = kc_contrast * amplitude_modulation
+
+            data = makesource.addsource(
+                data,
+                runtime.yx_known_companion_position[companion_index],
+                pa,
+                flux_psf,
+                image_center=yx_center_injection,
+                norm=-1 * kc_contrast,
+                jitter=0,
+                poisson_noise=False,
+                yx_anamorphism=runtime.yx_anamorphism,
+                right_handed=reduction_parameters.right_handed,
+                subpixel=True,
+                verbose=False,
+            )
+
+    return data, inverse_variance
 
 
 def run_complete_reduction(
@@ -1372,9 +1527,6 @@ def run_complete_reduction(
         flux_psf_full.shape[0], data_full.shape[0], len(instrument.wavelengths)
     )
 
-    if reduction_parameters.reduce_single_position is True:
-        all_results = OrderedDict()
-
     # Loop over reductions for different numbers of components
     # Check if number of components is iterable, if not make it iterable
     try:
@@ -1383,14 +1535,150 @@ def run_complete_reduction(
         number_of_components = [number_of_components]
         temporal_components_fraction = [temporal_components_fraction]
 
+    if wavelength_indices is None:
+        wavelength_indices = np.arange(data_full.shape[0])
+
+    # Dump the preprocessed per-wavelength data once, before the
+    # component/wavelength loops: the preprocessing is identical for every
+    # component fraction, and workers memmap the store read-only instead of
+    # receiving array copies.
+    shared_store = None
+    data_refs = {}
+    inverse_variance_refs = {}
     if (
         reduction_parameters.use_multiprocess
         and not reduction_parameters.reduce_single_position
     ):
-        ray.init(
-            num_cpus=min(runtime.ncpus, multiprocessing.cpu_count()),
-            # log_to_driver=False,
-            logging_level=logging.WARNING)
+        if data_crop_size is None:
+            yx_shape = (data_full.shape[-2], data_full.shape[-1])
+        else:
+            yx_shape = (data_crop_size, data_crop_size)
+        n_arrays = 2 if inverse_variance_full is not None else 1
+        required_bytes = int(
+            n_arrays
+            * len(wavelength_indices)
+            * data_full.shape[1]
+            * np.prod(yx_shape)
+            * np.dtype("float64").itemsize
+        )
+        shared_store = SharedArrayStore(
+            scratch_dir=reduction_parameters.scratch_dir,
+            required_bytes=required_bytes,
+        )
+        print("Shared array store: {}".format(shared_store.directory))
+        for wavelength_index in wavelength_indices:
+            flux_psf = psf_stamps[wavelength_index].astype("float64")
+            yx_center, yx_center_injection = _wavelength_geometry(
+                wavelength_index,
+                data_shape=data_full.shape,
+                data_crop_size=data_crop_size,
+                yx_center_full=yx_center_full,
+                yx_center_injection_full=yx_center_injection_full,
+            )
+            # Wavelengths with non-finite PSF or centers are skipped by the
+            # reduction loop below; skip dumping them as well.
+            if np.any(~np.isfinite(flux_psf)) or np.any(
+                ~np.isfinite(yx_center_injection)
+            ):
+                continue
+            if amplitude_modulation_full is None:
+                amplitude_modulation = np.ones(data_full.shape[1])
+            else:
+                amplitude_modulation = amplitude_modulation_full[wavelength_index, :]
+            data, inverse_variance = _prepare_wavelength_slice(
+                wavelength_index,
+                data_full=data_full,
+                inverse_variance_full=inverse_variance_full,
+                flux_psf=flux_psf,
+                pa=pa,
+                reduction_parameters=reduction_parameters,
+                runtime=runtime,
+                data_crop_size=data_crop_size,
+                yx_center_full=yx_center_full,
+                yx_center_injection=yx_center_injection,
+                amplitude_modulation=amplitude_modulation,
+            )
+            # Workers consume float64 (the cast `run_trap_search` would
+            # otherwise apply); dump that representation directly.
+            data_refs[wavelength_index] = shared_store.dump(
+                "data_lam{:03d}".format(wavelength_index),
+                data.astype("float64", copy=False),
+            )
+            if inverse_variance is not None:
+                inverse_variance_refs[wavelength_index] = shared_store.dump(
+                    "inverse_variance_lam{:03d}".format(wavelength_index),
+                    inverse_variance.astype("float64", copy=False),
+                )
+            else:
+                inverse_variance_refs[wavelength_index] = None
+
+    try:
+        return _run_reduction_loops(
+            number_of_components=number_of_components,
+            temporal_components_fraction=temporal_components_fraction,
+            wavelength_indices=wavelength_indices,
+            data_full=data_full,
+            inverse_variance_full=inverse_variance_full,
+            psf_stamps=psf_stamps,
+            pa=pa,
+            instrument=instrument,
+            reduction_parameters=reduction_parameters,
+            runtime=runtime,
+            stamp_sizes=stamp_sizes,
+            stamp_sizes_reduction=stamp_sizes_reduction,
+            yx_center_full=yx_center_full,
+            yx_center_injection_full=yx_center_injection_full,
+            amplitude_modulation_full=amplitude_modulation_full,
+            bad_pixel_mask_full=bad_pixel_mask_full,
+            data_crop_size=data_crop_size,
+            result_folder=result_folder,
+            prefix=prefix,
+            cross_validation=cross_validation,
+            overwrite=overwrite,
+            use_progress_bar=use_progress_bar,
+            shared_store=shared_store,
+            data_refs=data_refs,
+            inverse_variance_refs=inverse_variance_refs,
+        )
+    finally:
+        if shared_store is not None:
+            shared_store.cleanup()
+
+
+def _run_reduction_loops(
+    number_of_components,
+    temporal_components_fraction,
+    wavelength_indices,
+    data_full,
+    inverse_variance_full,
+    psf_stamps,
+    pa,
+    instrument,
+    reduction_parameters,
+    runtime,
+    stamp_sizes,
+    stamp_sizes_reduction,
+    yx_center_full,
+    yx_center_injection_full,
+    amplitude_modulation_full,
+    bad_pixel_mask_full,
+    data_crop_size,
+    result_folder,
+    prefix,
+    cross_validation,
+    overwrite,
+    use_progress_bar,
+    shared_store,
+    data_refs,
+    inverse_variance_refs,
+):
+    """Component/wavelength loops of `run_complete_reduction`.
+
+    Separated out so the shared-array store is cleaned up in a single
+    ``try/finally`` regardless of which internal path returns.
+    """
+    if reduction_parameters.reduce_single_position is True:
+        all_results = OrderedDict()
 
     for comp_index, ncomp in enumerate(number_of_components):
         print(
@@ -1399,10 +1687,6 @@ def run_complete_reduction(
 
         if reduction_parameters.reduce_single_position:
             wavelength_results = OrderedDict()
-        number_of_wavelengths = data_full.shape[0]
-
-        if wavelength_indices is None:
-            wavelength_indices = np.arange(number_of_wavelengths)
 
         # Loop over reduction for different wavelengths
         for (
@@ -1518,21 +1802,15 @@ def run_complete_reduction(
             #         ),
             #     )
 
-            # This block defines yx_center which gives the center of the output file
-            # based on cropping or no cropping
-            if yx_center_full is None:
-                if data_crop_size is None:
-                    yx_center = np.array(
-                        (data_full.shape[-2] // 2.0, data_full.shape[-1] // 2.0)
-                    )
-                else:
-                    yx_center = np.array((data_crop_size // 2.0, data_crop_size // 2.0))
-            else:
-                # try:
-                if data_crop_size is None:
-                    yx_center = np.array(yx_center_full[wavelength_index])
-                else:
-                    yx_center = np.array((data_crop_size // 2.0, data_crop_size // 2.0))
+            # Output-frame center and per-frame injection centers for this
+            # wavelength (shared with the store pre-dump pass).
+            yx_center, yx_center_injection = _wavelength_geometry(
+                wavelength_index,
+                data_shape=data_full.shape,
+                data_crop_size=data_crop_size,
+                yx_center_full=yx_center_full,
+                yx_center_injection_full=yx_center_injection_full,
+            )
 
             # Make companion mask before cropping to be consistent
             # Do this for each wavelength separately to account for PSF size
@@ -1573,35 +1851,6 @@ def run_complete_reduction(
             else:
                 known_companion_mask = None
 
-            if reduction_parameters.inject_fake:
-                # Return copy of data when injecting fake to not contaminate data
-                if data_crop_size is not None:
-                    data = crop_box_from_3D_cube(
-                        data_full[wavelength_index],
-                        data_crop_size,
-                        center_yx=np.round(yx_center_full[wavelength_index]),
-                    ).copy()
-                else:
-                    data = data_full[wavelength_index].copy()
-            else:
-                if data_crop_size is not None:
-                    data = crop_box_from_3D_cube(
-                        data_full[wavelength_index],
-                        data_crop_size,
-                        center_yx=np.round(yx_center_full[wavelength_index]),
-                    )
-                else:
-                    data = data_full[wavelength_index]
-
-            if inverse_variance_full is not None:
-                inverse_variance = crop_box_from_3D_cube(
-                    inverse_variance_full[wavelength_index],
-                    data_crop_size,
-                    center_yx=np.round(yx_center_full[wavelength_index]),
-                ).copy()
-            else:
-                inverse_variance = None
-
             flux_psf = psf_stamps[wavelength_index].astype("float64")
 
             if bad_pixel_mask_full is None:
@@ -1623,29 +1872,6 @@ def run_complete_reduction(
                         raise ValueError(
                             "Bad pixel mask, must either be one image or a number of images corresponding to wavelength"
                         )
-                except AttributeError:
-                    pass
-
-            if yx_center_injection_full is None:
-                yx_center_injection = yx_center
-            else:
-                try:
-                    if yx_center_injection_full.ndim == 3:
-                        if data_crop_size is None:
-                            yx_center_injection = yx_center_injection_full[
-                                wavelength_index, :
-                            ]
-                        else:
-                            # Image centers in cropped frame
-                            yx_center_injection = (
-                                yx_center_injection_full[wavelength_index, :]
-                                - np.round(yx_center_full[wavelength_index])
-                                + yx_center
-                            )
-                            # np.round(yx_center_full[wavelength_index]) - yx_center_injection_full[:, wavelength_index] \
-                            # + yx_center
-                            # Non-rounded image center in cropped frame
-                            yx_center = np.nanmedian(yx_center_injection, axis=0)
                 except AttributeError:
                     pass
 
@@ -1696,32 +1922,25 @@ def run_complete_reduction(
                 )
                 continue
 
-            if reduction_parameters.remove_known_companions:
-                # NOTE: This currently doesn't remove photon noise from variance map
-                # NOTE: Should change to faster implementation of `inject_model_into_data`
-
-                for companion_index, kc_contrast in enumerate(
-                    runtime.known_companion_contrast[wavelength_index]
-                ):
-                    # NOTE: Check format of known_companion_contrast and amplitude_modulation
-                    kc_contrast = kc_contrast * amplitude_modulation
-
-                    data = makesource.addsource(
-                        data,
-                        runtime.yx_known_companion_position[
-                            companion_index
-                        ],
-                        pa,
-                        flux_psf,
-                        image_center=yx_center_injection,
-                        norm=-1 * kc_contrast,
-                        jitter=0,
-                        poisson_noise=False,
-                        yx_anamorphism=runtime.yx_anamorphism,
-                        right_handed=reduction_parameters.right_handed,
-                        subpixel=True,
-                        verbose=False,
-                    )
+            if shared_store is not None and wavelength_index in data_refs:
+                # Preprocessed data was dumped to the shared store before the
+                # loops; pass references so workers memmap it read-only.
+                data = data_refs[wavelength_index]
+                inverse_variance = inverse_variance_refs[wavelength_index]
+            else:
+                data, inverse_variance = _prepare_wavelength_slice(
+                    wavelength_index,
+                    data_full=data_full,
+                    inverse_variance_full=inverse_variance_full,
+                    flux_psf=flux_psf,
+                    pa=pa,
+                    reduction_parameters=reduction_parameters,
+                    runtime=runtime,
+                    data_crop_size=data_crop_size,
+                    yx_center_full=yx_center_full,
+                    yx_center_injection=yx_center_injection,
+                    amplitude_modulation=amplitude_modulation,
+                )
 
             print("PSF Size: {}".format(runtime.reduction_mask_psf_size))
             if reduction_parameters.reduce_single_position:
@@ -1800,8 +2019,7 @@ def run_complete_reduction(
                     scores = mad_std(np.array(ncomp_residuals), axis=3)
                     best_scores = np.argmin(scores, axis=1)
                     median_best_scores = np.median(best_scores, axis=1)
-                    ray.shutdown()
-                    
+
                     return ncomp_residuals, scores, best_scores, median_best_scores
                     
                 (
@@ -1849,12 +2067,6 @@ def run_complete_reduction(
             all_results[
                 "{}".format(temporal_components_fraction[comp_index])
             ] = wavelength_results
-
-    if (
-        reduction_parameters.use_multiprocess
-        and not reduction_parameters.reduce_single_position
-    ):
-        ray.shutdown()
 
     if reduction_parameters.reduce_single_position:
         return all_results

--- a/src/trap/shared_arrays.py
+++ b/src/trap/shared_arrays.py
@@ -1,0 +1,142 @@
+"""Shared read-only array store for multiprocessing.
+
+Large input arrays are dumped once as ``.npy`` files to a scratch directory
+(``/dev/shm`` on cluster nodes, the system temp dir otherwise, see
+`trap.parameters.resolve_scratch_dir`). Worker processes open them with
+``np.load(mmap_mode="r")``, so the OS page cache provides a single shared
+in-RAM copy per node instead of one copy per process.
+
+Workers never receive the arrays themselves, only lightweight picklable
+references (`SharedArrayRef`, optionally sliced via ``ref[key]``). Call
+`resolve` on a received argument to obtain the (read-only) array; plain
+arrays pass through unchanged, so the same worker code serves both the
+serial and the parallel path.
+
+BLAS thread capping in workers is handled by joblib's loky backend
+(``parallel_config(inner_max_num_threads=1)`` at the dispatch sites), which
+sets the thread-limit environment variables before the worker processes
+load their BLAS.
+
+@author: Matthias Samland
+         MPIA Heidelberg
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from trap.parameters import resolve_scratch_dir
+
+__all__ = ["SharedArrayRef", "SharedArrayStore", "resolve"]
+
+# Per-process cache of opened memmaps, keyed by file path. Store directories
+# are unique per store (mkdtemp), so a path never refers to two different
+# arrays within one reduction.
+_MEMMAP_CACHE: dict = {}
+
+
+@dataclass(frozen=True)
+class SharedArrayRef:
+    """Picklable reference to an array stored in a `SharedArrayStore`.
+
+    Optionally carries an index expression (``ref[key]``) that is applied
+    after memmapping, so per-wavelength crops travel as index bounds rather
+    than array copies.
+    """
+
+    path: str
+    key: Optional[Any] = None
+
+    def __getitem__(self, key) -> "SharedArrayRef":
+        if self.key is not None:
+            raise ValueError("SharedArrayRef already carries an index expression.")
+        return SharedArrayRef(self.path, key)
+
+    def load(self) -> np.ndarray:
+        """Memmap the backing file (cached per process) and apply the index."""
+        try:
+            array = _MEMMAP_CACHE[self.path]
+        except KeyError:
+            array = np.load(self.path, mmap_mode="r")
+            _MEMMAP_CACHE[self.path] = array
+        if self.key is not None:
+            array = array[self.key]
+        return array
+
+
+def resolve(obj):
+    """Return the array behind ``obj``.
+
+    `SharedArrayRef` instances are memmapped (read-only) and sliced; any
+    other object (including None and plain arrays) is returned unchanged.
+    """
+    if isinstance(obj, SharedArrayRef):
+        return obj.load()
+    return obj
+
+
+class SharedArrayStore:
+    """Directory of ``.npy`` files shared read-only with worker processes.
+
+    Use as a context manager; the backing files are deleted on exit.
+
+    Parameters
+    ----------
+    scratch_dir : str or Path, optional
+        Directory in which to create the store. If None, resolved via
+        `trap.parameters.resolve_scratch_dir` (using ``required_bytes``
+        to check ``/dev/shm`` headroom).
+    required_bytes : int, optional
+        Estimated total size of the arrays to be stored.
+    """
+
+    def __init__(self, scratch_dir=None, required_bytes=None):
+        base_dir = resolve_scratch_dir(scratch_dir, required_bytes)
+        base_dir.mkdir(parents=True, exist_ok=True)
+        self.directory = Path(tempfile.mkdtemp(prefix="trap_store_", dir=base_dir))
+
+    def _path(self, name: str) -> Path:
+        return self.directory / f"{name}.npy"
+
+    def dump(self, name: str, array: np.ndarray) -> SharedArrayRef:
+        """Write ``array`` to the store and return a reference to it."""
+        path = self._path(name)
+        np.save(path, np.ascontiguousarray(array))
+        return SharedArrayRef(str(path))
+
+    def create(self, name: str, shape, dtype) -> np.ndarray:
+        """Create an empty array in the store and return it as a writable memmap.
+
+        Use this to fill large arrays incrementally (e.g. one wavelength
+        slice at a time) without materializing them in memory first. Obtain
+        the shareable reference afterwards via `ref`.
+        """
+        return np.lib.format.open_memmap(
+            self._path(name), mode="w+", dtype=dtype, shape=shape
+        )
+
+    def ref(self, name: str) -> SharedArrayRef:
+        """Return a reference to a previously dumped/created array."""
+        path = self._path(name)
+        if not path.exists():
+            raise KeyError(f"No array named {name!r} in store {self.directory}")
+        return SharedArrayRef(str(path))
+
+    def cleanup(self):
+        """Delete the store directory and all arrays in it."""
+        for path in self.directory.glob("*.npy"):
+            _MEMMAP_CACHE.pop(str(path), None)
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+    def __enter__(self) -> "SharedArrayStore":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.cleanup()
+        return False

--- a/src/trap/utils.py
+++ b/src/trap/utils.py
@@ -5,103 +5,18 @@ Routines used in TRAP
          MPIA Heidelberg
 """
 
-from asyncio import Event
-from typing import Tuple
-
 import dill
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.fft as fft
-import ray
 import scipy.interpolate as sinterp
 from numba import njit
 from numpy.random import default_rng
-from ray.actor import ActorHandle
 from scipy import ndimage
 from scipy.ndimage import spline_filter
 from tqdm import tqdm
 
 from trap import regressor_selection
-
-
-@ray.remote
-class ProgressBarActor:
-    counter: int
-    delta: int
-    event: Event
-
-    def __init__(self) -> None:
-        self.counter = 0
-        self.delta = 0
-        self.event = Event()
-
-    def update(self, num_items_completed: int) -> None:
-        """Updates the ProgressBar with the incremental
-        number of items that were just completed.
-        """
-        self.counter += num_items_completed
-        self.delta += num_items_completed
-        self.event.set()
-
-    async def wait_for_update(self) -> Tuple[int, int]:
-        """Blocking call.
-
-        Waits until somebody calls `update`, then returns a tuple of
-        the number of updates since the last call to
-        `wait_for_update`, and the total number of completed items.
-        """
-        await self.event.wait()
-        self.event.clear()
-        saved_delta = self.delta
-        self.delta = 0
-        return saved_delta, self.counter
-
-    def get_counter(self) -> int:
-        """
-        Returns the total number of complete items.
-        """
-        return self.counter
-
-# Back on the local node, once you launch your remote Ray tasks, call
-# `print_until_done`, which will feed everything back into a `tqdm` counter.
-
-
-class ProgressBar:
-    progress_actor: ActorHandle
-    total: int
-    description: str
-    pbar: tqdm
-
-    def __init__(self, total: int, description: str = ""):
-        # Ray actors don't seem to play nice with mypy, generating
-        # a spurious warning for the following line,
-        # which we need to suppress. The code is fine.
-        self.progress_actor = ProgressBarActor.remote()  # type: ignore
-        self.total = total
-        self.description = description
-
-    @property
-    def actor(self) -> ActorHandle:
-        """Returns a reference to the remote `ProgressBarActor`.
-
-        When you complete tasks, call `update` on the actor.
-        """
-        return self.progress_actor
-
-    def print_until_done(self) -> None:
-        """Blocking call.
-
-        Do this after starting a series of remote Ray tasks, to which you've
-        passed the actor handle. Each of them calls `update` on the actor.
-        When the progress meter reaches 100%, this method returns.
-        """
-        pbar = tqdm(desc=self.description, total=self.total)
-        while True:
-            delta, counter = ray.get(self.actor.wait_for_update.remote())
-            pbar.update(delta)
-            if counter >= self.total:
-                pbar.close()
-                return
 
 
 def shuffle_and_equalize_relative_positions(

--- a/tests/test_coronagraph_throughput.py
+++ b/tests/test_coronagraph_throughput.py
@@ -1,0 +1,119 @@
+import numpy as np
+import pytest
+
+from trap.makesource import (
+    coronagraph_throughput_factor,
+    coronagraph_transmission_to_pixels,
+)
+from trap.parameters import TrapReductionConfig, build_runtime_state
+
+
+def test_to_pixels_converts_and_sorts():
+    # 10 mas/pixel: 100 mas -> 10 pix, 50 mas -> 5 pix; input unsorted
+    table_mas = np.array([[100.0, 1.0], [50.0, 0.5], [0.0, 0.0]])
+    out = coronagraph_transmission_to_pixels(table_mas, mas_per_pixel=10.0)
+    assert out.shape == (3, 2)
+    np.testing.assert_allclose(out[:, 0], [0.0, 5.0, 10.0])
+    np.testing.assert_allclose(out[:, 1], [0.0, 0.5, 1.0])
+
+
+def test_to_pixels_accepts_pair():
+    sep_mas = np.array([0.0, 50.0, 100.0])
+    throughput = np.array([0.0, 0.5, 1.0])
+    out = coronagraph_transmission_to_pixels((sep_mas, throughput), mas_per_pixel=10.0)
+    np.testing.assert_allclose(out[:, 0], [0.0, 5.0, 10.0])
+
+
+def test_to_pixels_warns_when_last_not_one():
+    table_mas = np.array([[0.0, 0.0], [100.0, 0.8]])
+    with pytest.warns(UserWarning):
+        coronagraph_transmission_to_pixels(table_mas, mas_per_pixel=10.0)
+
+
+def test_factor_interpolates():
+    table_pix = np.array([[0.0, 0.0], [5.0, 0.5], [10.0, 1.0]])
+    assert coronagraph_throughput_factor(2.5, table_pix) == pytest.approx(0.25)
+
+
+def test_factor_beyond_table_is_one():
+    table_pix = np.array([[0.0, 0.0], [10.0, 1.0]])
+    assert coronagraph_throughput_factor(50.0, table_pix) == pytest.approx(1.0)
+
+
+def test_factor_below_table_clamps_to_first():
+    table_pix = np.array([[3.0, 0.2], [10.0, 1.0]])
+    assert coronagraph_throughput_factor(0.0, table_pix) == pytest.approx(0.2)
+
+
+def _minimal_runtime(coronagraph_transmission, mas_per_pixel):
+    config = TrapReductionConfig(
+        search_region_outer_bound=20,
+        data_auto_crop=False,
+        data_crop_size=101,
+        coronagraph_transmission=coronagraph_transmission,
+    )
+    return build_runtime_state(
+        config=config,
+        data_shape=(1, 4, 101, 101),
+        stamp_sizes=np.array([21]),
+        stamp_sizes_reduction=np.array([19]),
+        max_shift=0.0,
+        mas_per_pixel=mas_per_pixel,
+    )
+
+
+def test_runtime_builds_pixel_table():
+    table_mas = np.array([[0.0, 0.0], [50.0, 0.5], [100.0, 1.0]])
+    runtime = _minimal_runtime(table_mas, mas_per_pixel=10.0)
+    assert runtime.coronagraph_transmission_pix is not None
+    np.testing.assert_allclose(runtime.coronagraph_transmission_pix[:, 0], [0.0, 5.0, 10.0])
+
+
+def test_runtime_table_none_by_default():
+    runtime = _minimal_runtime(None, mas_per_pixel=10.0)
+    assert runtime.coronagraph_transmission_pix is None
+
+
+def test_to_pixels_two_point_pair():
+    out = coronagraph_transmission_to_pixels(
+        (np.array([0.0, 100.0]), np.array([0.0, 1.0])), mas_per_pixel=10.0
+    )
+    np.testing.assert_allclose(out[:, 0], [0.0, 10.0])
+    np.testing.assert_allclose(out[:, 1], [0.0, 1.0])
+
+
+def test_to_pixels_clips_and_warns_out_of_range():
+    table_mas = np.array([[0.0, 0.0], [100.0, 1.5]])
+    with pytest.warns(UserWarning):
+        out = coronagraph_transmission_to_pixels(table_mas, mas_per_pixel=10.0)
+    assert out[-1, 1] == pytest.approx(1.0)
+
+
+def test_runtime_requires_mas_per_pixel():
+    table_mas = np.array([[0.0, 0.0], [50.0, 0.5], [100.0, 1.0]])
+    with pytest.raises(ValueError):
+        _minimal_runtime(table_mas, mas_per_pixel=None)
+
+
+def test_to_reduction_parameters_with_transmission():
+    config = TrapReductionConfig(
+        coronagraph_transmission=np.array([[0.0, 0.0], [100.0, 1.0]])
+    )
+    with pytest.warns(DeprecationWarning):
+        config.to_reduction_parameters()
+
+
+def test_amplitude_scaling_does_not_mutate_shared_array():
+    # Mirrors the trap_one_position logic: amplitude_modulation comes from
+    # ray.put and is shared read-only across positions.
+    table_pix = np.array([[0.0, 0.0], [5.0, 0.5], [10.0, 1.0]])
+    shared = np.ones(4)
+    signal_position = np.array([0.0, 2.5])  # |pos| = 2.5 px -> throughput 0.25
+
+    separation_pix = np.hypot(signal_position[0], signal_position[1])
+    factor = coronagraph_throughput_factor(separation_pix, table_pix)
+    scaled = shared * factor
+
+    assert factor == pytest.approx(0.25)
+    np.testing.assert_allclose(scaled, np.full(4, 0.25))
+    np.testing.assert_allclose(shared, np.ones(4))  # shared untouched

--- a/tests/test_parallel_equivalence.py
+++ b/tests/test_parallel_equivalence.py
@@ -1,0 +1,124 @@
+"""Serial-vs-parallel equivalence of the reduction on a synthetic cube.
+
+WP1 acceptance test: the joblib/memmap-store parallel path must produce the
+same detection maps as the serial loop.
+"""
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from trap import makesource
+from trap.parameters import Instrument, TrapReductionConfig
+from trap.reduction_wrapper import run_complete_reduction
+
+
+@pytest.fixture(scope="module")
+def synthetic_dataset():
+    rng = np.random.default_rng(42)
+    n_frames = 16
+    image_size = 31
+
+    pa = np.linspace(0.0, 40.0, n_frames)
+
+    # Gaussian PSF stamp (odd size, centered on pixel)
+    stamp_size = 21
+    yy, xx = np.mgrid[:stamp_size, :stamp_size] - stamp_size // 2
+    sigma = 3.5 / 2.355
+    psf = np.exp(-(xx**2 + yy**2) / (2 * sigma**2))
+    psf /= psf.sum()
+
+    data = rng.normal(loc=0.0, scale=1e-4, size=(n_frames, image_size, image_size))
+    # Inject a companion at 5 pix separation
+    data = makesource.addsource(
+        data,
+        pos=(0.0, 5.0),
+        pa=pa,
+        psf_arr=psf,
+        norm=np.full(n_frames, 5e-3),
+        jitter=0,
+        poisson_noise=False,
+        subpixel=True,
+        copy=True,
+        verbose=False,
+    )
+
+    instrument = Instrument(
+        name="synthetic",
+        pixel_scale=u.pixel_scale(12.25 * u.mas / u.pixel),
+        telescope_diameter=8.0 * u.m,
+        detector_gain=1.0,
+        readnoise=0.0,
+        instrument_type="photometry",
+        wavelengths=np.array([1.6]) * u.micron,
+    )
+    return data, psf, pa, instrument
+
+
+def _run_reduction(synthetic_dataset, result_folder, use_multiprocess):
+    data, psf, pa, instrument = synthetic_dataset
+    config = TrapReductionConfig(
+        search_region_inner_bound=4,
+        search_region_outer_bound=7,
+        data_auto_crop=False,
+        data_crop_size=None,
+        temporal_model=True,
+        temporal_plus_spatial_model=False,
+        spatial_model=False,
+        use_multiprocess=use_multiprocess,
+        ncpus=2,
+        result_folder=str(result_folder),
+        verbose=False,
+    )
+    run_complete_reduction(
+        data_full=data.copy(),
+        flux_psf_full=psf.copy(),
+        pa=pa,
+        instrument=instrument,
+        reduction_parameters=config,
+        temporal_components_fraction=[0.25],
+        overwrite=True,
+        use_progress_bar=False,
+    )
+    detection_files = sorted(result_folder.glob("detection_*.fits"))
+    assert len(detection_files) == 1, (
+        f"Expected one detection image, found: {[f.name for f in detection_files]}"
+    )
+    return fits.getdata(detection_files[0])
+
+
+def test_serial_and_parallel_reductions_are_equivalent(synthetic_dataset, tmp_path):
+    serial_folder = tmp_path / "serial"
+    parallel_folder = tmp_path / "parallel"
+    serial_folder.mkdir()
+    parallel_folder.mkdir()
+
+    detection_serial = _run_reduction(
+        synthetic_dataset, serial_folder, use_multiprocess=False
+    )
+    detection_parallel = _run_reduction(
+        synthetic_dataset, parallel_folder, use_multiprocess=True
+    )
+
+    assert detection_serial.shape == detection_parallel.shape
+    # Maps: 0) contrast, 1) uncertainty, 2) SNR; NaN outside the search region.
+    np.testing.assert_allclose(
+        detection_parallel,
+        detection_serial,
+        rtol=1e-10,
+        atol=0.0,
+        equal_nan=True,
+    )
+
+
+def test_parallel_reduction_detects_injected_companion(synthetic_dataset, tmp_path):
+    result_folder = tmp_path / "detection"
+    result_folder.mkdir()
+    detection = _run_reduction(synthetic_dataset, result_folder, use_multiprocess=True)
+
+    contrast = detection[0]
+    center = contrast.shape[0] // 2
+    # Injected at (dy, dx) = (0, 5) relative to center with contrast 5e-3
+    measured = contrast[center, center + 5]
+    assert measured == pytest.approx(5e-3, rel=0.2)

--- a/tests/test_shared_arrays.py
+++ b/tests/test_shared_arrays.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pytest
+
+from trap.parameters import resolve_scratch_dir
+from trap.shared_arrays import SharedArrayRef, SharedArrayStore, resolve
+
+
+def test_dump_and_resolve_roundtrip(tmp_path):
+    array = np.arange(24, dtype="float64").reshape(2, 3, 4)
+    with SharedArrayStore(scratch_dir=tmp_path) as store:
+        ref = store.dump("data", array)
+        loaded = resolve(ref)
+        np.testing.assert_array_equal(loaded, array)
+        assert isinstance(loaded, np.memmap)
+
+
+def test_resolved_memmap_is_read_only(tmp_path):
+    array = np.zeros((4, 4))
+    with SharedArrayStore(scratch_dir=tmp_path) as store:
+        loaded = resolve(store.dump("data", array))
+        with pytest.raises(ValueError):
+            loaded[0, 0] = 1.0
+
+
+def test_ref_slicing_returns_view(tmp_path):
+    array = np.arange(60, dtype="float64").reshape(3, 4, 5)
+    with SharedArrayStore(scratch_dir=tmp_path) as store:
+        ref = store.dump("data", array)
+        sliced = resolve(ref[np.s_[1, :, 1:3]])
+        np.testing.assert_array_equal(sliced, array[1, :, 1:3])
+        with pytest.raises(ValueError):
+            _ = ref[0][0]  # only one index expression allowed
+
+
+def test_resolve_passes_through_plain_objects():
+    array = np.ones(3)
+    assert resolve(array) is array
+    assert resolve(None) is None
+
+
+def test_refs_are_picklable(tmp_path):
+    import pickle
+
+    array = np.arange(10, dtype="float64")
+    with SharedArrayStore(scratch_dir=tmp_path) as store:
+        ref = store.dump("data", array)[np.s_[2:5]]
+        restored = pickle.loads(pickle.dumps(ref))
+        np.testing.assert_array_equal(resolve(restored), array[2:5])
+
+
+def test_create_fills_incrementally(tmp_path):
+    with SharedArrayStore(scratch_dir=tmp_path) as store:
+        memmap = store.create("data", shape=(3, 4), dtype="float64")
+        for i in range(3):
+            memmap[i] = i
+        memmap.flush()
+        loaded = resolve(store.ref("data"))
+        np.testing.assert_array_equal(loaded, np.repeat(np.arange(3.0), 4).reshape(3, 4))
+
+
+def test_ref_of_missing_array_raises(tmp_path):
+    with SharedArrayStore(scratch_dir=tmp_path) as store:
+        with pytest.raises(KeyError):
+            store.ref("missing")
+
+
+def test_cleanup_removes_directory(tmp_path):
+    store = SharedArrayStore(scratch_dir=tmp_path)
+    store.dump("data", np.zeros(3))
+    directory = store.directory
+    assert directory.exists()
+    store.cleanup()
+    assert not directory.exists()
+
+
+def test_resolve_scratch_dir_explicit_wins(tmp_path):
+    assert resolve_scratch_dir(scratch_dir=tmp_path) == tmp_path
+
+
+def test_resolve_scratch_dir_returns_existing_directory():
+    resolved = resolve_scratch_dir(required_bytes=1024)
+    assert resolved.is_dir()
+
+
+def test_resolve_scratch_dir_huge_request_avoids_dev_shm():
+    # A store larger than any /dev/shm must fall back to the temp dir.
+    resolved = resolve_scratch_dir(required_bytes=10**18)
+    assert str(resolved) != "/dev/shm"


### PR DESCRIPTION
## Summary

**WP1** of the multiprocessing/multi-wavelength work: replaces the Ray-based parallelism with a **joblib/loky** backend plus a **memmap shared-array store**, removing Ray as a dependency while keeping reduction results equivalent.

Headline commit: `08bd2c6` — *Replace Ray with joblib/loky + memmap shared-array store (WP1)*

### Main changes
- `reduction_wrapper.py` — reworked parallel execution over joblib/loky (bulk of the diff).
- `shared_arrays.py` (new) — memmap-backed shared-array store for worker processes.
- `parameters.py`, `makesource.py`, `detection.py` — supporting adjustments.
- Tests: `test_parallel_equivalence.py`, `test_shared_arrays.py` (+ `test_coronagraph_throughput.py`).
- `pyproject.toml` / `pixi.toml` — drop Ray, add joblib/loky.

### Note on scope / merge base
`develop` is currently behind `main`: it lacks the already-merged coronagraph-throughput (PR #32) and nan-cutout (PR #30) commits. Because WP1 was branched off `main`, this PR's diff also carries those commits — merging it brings `develop` up to `main` **and** adds WP1. All of that extra content is already released on `main`.

### Follow-ups (not in this PR)
- WP1.5 (cross-validation component selection) — separate branch `feature/wp1.5-cross-validation`, to be PR'd later.
- WP2 (multi-wavelength regressors) — `feature/wp2-multiwavelength-regressors`.