### PR TITLE
Stop one bad candidate from aborting a whole target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to this project will be documented in this file.  
 This project adheres to [Keep a Changelog](https://keepachangelog.com/) and [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **A single unfittable candidate no longer aborts the whole target.** `fit_2d_gaussian`
+  used `LevMarLSQFitter`, which enforces bounds by clipping inside the objective: a
+  parameter driven past a bound lands in a flat region whose numerical Jacobian column is
+  zero, MINPACK returns NaN parameters and astropy raises `NonFiniteValueError`. Fit A
+  leaves both widths and the orientation free, so this fired on speckle structure — 4 of
+  72,464 above-threshold positions across four SPHERE/IRDIS targets, each one fatal. The
+  fitter is now `TRFLSQFitter` (genuinely bounded, and what astropy recommends for bounded
+  models), with a fixed-shape retry behind it and a NaN row carrying `fit_ok=False` as the
+  last resort. An unfittable cutout — including the all-NaN case that previously raised
+  `RuntimeError` — is reported, not raised. Cutouts trimmed at the frame edge no longer
+  misalign the model grid.
+- **A candidate at the inner working angle no longer destroys the reduction.** With
+  `search_region_inner_bound=1` the contrast table is finite from 1 px, so the
+  `smallest_separation_in_pixel` guard admitted the coronagraph centre residual as a
+  candidate; rebuilding the noise profile with that candidate masked at
+  `companion_mask_radius=11` blanked every annulus from 1 to 8 px, leaving its own fit
+  cutout entirely NaN. Three independent guards now apply: new
+  `DetectionParameters.minimum_candidate_separation` (5 px) drops candidates inside the
+  stellar PSF core, `make_radial_profile` falls back to the un-masked annulus statistic
+  below `minimum_annulus_pixels` (10) instead of writing NaN, and a companion's exclusion
+  radius is capped at `separation - 1` so it cannot swallow the annuli it needs.
+- **A failing template or per-channel astrometry no longer costs the combined tables.**
+  `match_all_templates` iterates templates in dict order and `measure_per_channel_astrometry`
+  runs *before* the overall tables are written, so one failure lost every later template and
+  both `overall_*.csv` files even when the per-template tables were already complete. Each
+  template, the contrast plotting, and the per-channel astrometry are now individually
+  log-and-continue; the combined tables are built from whatever succeeded.
+
+### Added
+- **SNR-scaled candidate exclusion radius.** The radius blanked around an accepted peak
+  scales as `sqrt(snr / candidate_threshold)`, capped at `2.5 ×` the base radius. A fixed
+  radius is tuned for a marginal detection, but a bright binary's contamination is a swarm
+  of detached above-threshold blobs that re-enter the search as spurious candidates: on
+  HD_140408 (125σ binary at 35 px) this cut the candidate list from 18/14 to 9/6 per channel
+  while leaving three clean targets — including one with a real 30σ source — unchanged.
+  Connected above-threshold regions are masked alongside the disk. Controlled by
+  `exclusion_radius_snr_scaling` / `max_exclusion_radius_factor`.
+- **`DetectionParameters.candidate_exclusion_radius`** decouples the iterative search
+  exclusion radius from `search_radius`, which also serves as the cross-template and
+  cross-channel association radius — widening one used to silently widen the other. `None`
+  keeps the previous shared behaviour.
+- **`DetectionParameters.max_candidates`** (50) bounds the previously unlimited candidate
+  loop. Every candidate costs a full contrast-table renormalization, so a saturated map was
+  a runtime hazard as much as a scientific one; truncation is logged.
+
 ## [2.0.0] - 2026-07-30
 
 First release with validated astrometry. Contains breaking changes — see the entries marked

--- a/src/trap/detection.py
+++ b/src/trap/detection.py
@@ -26,7 +26,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 from natsort import natsorted
 from numpy import interp
 from photutils.aperture import CircularAnnulus
-from scipy import linalg, stats
+from scipy import linalg, ndimage, stats
 from species import SpeciesInit
 from species.data.database import Database
 from species.read.read_model import ReadModel
@@ -46,6 +46,46 @@ from trap.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Mirrors `DetectionParameters.minimum_candidate_separation`; duplicated as a
+# module constant so the candidate finders keep a sane floor when called
+# directly (tests, notebooks) rather than through the configured entry points.
+DEFAULT_MINIMUM_CANDIDATE_SEPARATION = 5.0
+
+# Mirrors `DetectionParameters.max_candidates`. Every candidate costs a full
+# contrast-table renormalization, so an unbounded list is a runtime hazard as
+# much as a scientific one.
+DEFAULT_MAX_CANDIDATES = 50
+
+# Cap on the SNR-scaled candidate exclusion radius, as a multiple of the base
+# radius. 2.5 takes IRDIS's 11 px base to ~28 px, which is where a 100-sigma
+# binary's blob swarm stops on the HD_140408 test case; more starts eating real
+# search area.
+DEFAULT_MAX_EXCLUSION_RADIUS_FACTOR = 2.5
+
+
+def _resolve_exclusion_radius(candidate_exclusion_radius, search_radius):
+    """Fall back to `search_radius` when no separate exclusion radius is set."""
+    if candidate_exclusion_radius is None:
+        return search_radius
+    return candidate_exclusion_radius
+
+
+def _scaled_exclusion_radius(
+    snr, candidate_threshold, mask_radius, max_factor, enabled=True
+):
+    """Grow a peak's exclusion radius with its significance.
+
+    The contaminated area around a source scales with how far its wings stay
+    above threshold, which grows with SNR; a radius tuned for a marginal
+    detection leaves a bright binary's wings to re-enter the search as dozens of
+    spurious candidates. `sqrt` keeps the growth gentle and the cap keeps a very
+    bright source from blanking the search region.
+    """
+    if not enabled or not np.isfinite(snr) or snr <= candidate_threshold:
+        return mask_radius
+    factor = float(np.sqrt(snr / candidate_threshold))
+    return mask_radius * float(np.clip(factor, 1.0, max_factor))
 
 # plt.style.use("paper")
 
@@ -67,6 +107,7 @@ def make_radial_profile(
     operation="mad_std",
     yx_center=None,
     known_companion_mask=None,
+    minimum_annulus_pixels=10,
 ):
     """
     Compute the radial profile of a 2D data array.
@@ -78,6 +119,12 @@ def make_radial_profile(
     - operation (str, optional): The operation to be applied to the data within each bin. Options are "mad_std", "median", "mean", "min", "std", and "percentiles".
     - yx_center (tuple, optional): The center coordinates of the data array. If not provided, the center is assumed to be the center of the data array.
     - known_companion_mask (ndarray, optional): A mask indicating the positions of known companions to be excluded from the profile.
+    - minimum_annulus_pixels (int, optional): Fall back to the un-masked annulus when
+      excluding known companions leaves fewer than this many finite pixels. Without
+      the fallback a companion mask that covers a whole annulus makes the profile —
+      and therefore the normalized detection image — NaN across that annulus, which
+      no downstream fit can recover from. Set to 0 to restore the un-guarded
+      behaviour.
 
     Returns:
     - profile (ndarray): The computed radial profile.
@@ -143,6 +190,18 @@ def make_radial_profile(
                 mask_wo_companion = mask
             else:
                 mask_wo_companion = np.logical_and(mask, ~known_companion_mask)
+                if (
+                    np.count_nonzero(np.isfinite(data[mask_wo_companion]))
+                    < minimum_annulus_pixels
+                ):
+                    # Keeping the companion in is a biased noise estimate; a NaN
+                    # annulus is an unusable one. Bias high (which suppresses the
+                    # source's own SNR) rather than lose the annulus entirely.
+                    logger.debug(
+                        "Annulus at separation %d retains too few unmasked pixels; "
+                        "falling back to the un-masked statistic.", separation,
+                    )
+                    mask_wo_companion = mask
 
             # Data on which statistic is applied
             annulus_data_1d = data[mask_wo_companion]
@@ -198,6 +257,25 @@ def make_radial_profile(
     return profile, np.array(values)
 
 
+def _adaptive_companion_mask_radius(
+    yx_relative_position, companion_mask_radius, minimum_companion_mask_radius
+):
+    """Shrink a companion's exclusion radius so it cannot swallow its own annuli.
+
+    A fixed radius applied to a source at small separation covers every annulus
+    inside it, leaving `make_radial_profile` nothing to work with. Capping the
+    radius at `separation - 1` keeps unmasked pixels at every separation the
+    source could be measured at; the floor keeps the source's PSF core out of
+    the noise estimate.
+    """
+    separation = float(np.hypot(yx_relative_position[0], yx_relative_position[1]))
+    return float(
+        np.clip(
+            separation - 1.0, minimum_companion_mask_radius, companion_mask_radius
+        )
+    )
+
+
 def make_contrast_curve(
     detection_image,
     radial_bounds=None,
@@ -206,6 +284,8 @@ def make_contrast_curve(
     pixel_scale=12.25,
     yx_known_companion_position=None,
     mask_above_sigma=None,
+    minimum_companion_mask_radius=3.0,
+    minimum_annulus_pixels=10,
 ):
     yx_dim = (detection_image.shape[-2], detection_image.shape[-1])
 
@@ -216,30 +296,25 @@ def make_contrast_curve(
     if yx_known_companion_position is not None:
         yx_known_companion_position = np.array(yx_known_companion_position)
         if yx_known_companion_position.ndim == 1:
-            detected_signal_mask = regressor_selection.make_signal_mask(
-                yx_dim,
-                yx_known_companion_position,
-                companion_mask_radius,
-                relative_pos=True,
-                yx_center=None,
-            )
-        elif yx_known_companion_position.ndim == 2:
-            detected_signal_masks = []
-            for yx_pos in yx_known_companion_position:
-                detected_signal_masks.append(
-                    regressor_selection.make_signal_mask(
-                        yx_dim,
-                        yx_pos,
-                        companion_mask_radius,
-                        relative_pos=True,
-                        yx_center=None,
-                    )
-                )
-            detected_signal_mask = np.logical_or.reduce(detected_signal_masks)
-        else:
+            yx_known_companion_position = yx_known_companion_position[None, :]
+        elif yx_known_companion_position.ndim != 2:
             raise ValueError(
                 "Dimensionality of known companion positions for contrast curve too large."
             )
+        detected_signal_masks = []
+        for yx_pos in yx_known_companion_position:
+            detected_signal_masks.append(
+                regressor_selection.make_signal_mask(
+                    yx_dim,
+                    yx_pos,
+                    _adaptive_companion_mask_radius(
+                        yx_pos, companion_mask_radius, minimum_companion_mask_radius
+                    ),
+                    relative_pos=True,
+                    yx_center=None,
+                )
+            )
+        detected_signal_mask = np.logical_or.reduce(detected_signal_masks)
     else:
         detected_signal_mask = None
         # detected_signal_mask = np.zeros(detection_image[0].shape, dtype='bool')
@@ -250,6 +325,7 @@ def make_contrast_curve(
         bin_width=bin_width,
         operation="mad_std",
         known_companion_mask=detected_signal_mask,
+        minimum_annulus_pixels=minimum_annulus_pixels,
     )
     normalized_detection_image = detection_image[2] / snr_norm_profile
 
@@ -266,6 +342,7 @@ def make_contrast_curve(
             bin_width=bin_width,
             operation="mad_std",
             known_companion_mask=detected_signal_mask,
+            minimum_annulus_pixels=minimum_annulus_pixels,
         )
         normalized_detection_image = detection_image[2] / snr_norm_profile
     else:
@@ -291,6 +368,7 @@ def make_contrast_curve(
         bin_width=bin_width,
         operation="percentiles",
         known_companion_mask=detected_signal_mask,
+        minimum_annulus_pixels=minimum_annulus_pixels,
     )
     _, min_uncertainty_values = make_radial_profile(
         local_detection_image[1],
@@ -298,6 +376,7 @@ def make_contrast_curve(
         bin_width=bin_width,
         operation="min",
         known_companion_mask=detected_signal_mask,
+        minimum_annulus_pixels=minimum_annulus_pixels,
     )
 
     # contrast_norm_profile, contrast_norm_values = make_radial_profile(
@@ -1057,6 +1136,50 @@ def plot_distribution(
     plt.show()
 
 
+def _failed_gaussian_fit_result(yx_position, yx_center, cutout_shape):
+    """Build a `fit_2d_gaussian` result whose parameters are all NaN.
+
+    Returned instead of raising when a candidate cannot be fitted, so one
+    pathological position costs that candidate's row rather than the whole
+    target. `fit_ok=False` propagates into the candidate tables, where the
+    existing shape validation drops the row.
+
+    Parameters
+    ----------
+    yx_position : tuple of float
+        Candidate position in original image coordinates, used verbatim as the
+        reported (unfitted) position.
+    yx_center : tuple of float
+        Image center, for the relative position.
+    cutout_shape : tuple of int
+        Shape of the attempted cutout, so `mask` matches a successful result.
+
+    Returns
+    -------
+    dict
+        Same keys as a successful `fit_2d_gaussian` result.
+    """
+    nan_model = models.Gaussian2D(
+        amplitude=np.nan, x_mean=np.nan, y_mean=np.nan,
+        x_stddev=np.nan, y_stddev=np.nan, theta=np.nan,
+    )
+    return {
+        "parameters": nan_model,
+        "model": np.full(cutout_shape, np.nan),
+        "cutout": np.full(cutout_shape, np.nan),
+        "yx_fit_position_orig": (float(yx_position[0]), float(yx_position[1])),
+        "yx_fit_relative": (
+            float(yx_position[0]) - yx_center[0],
+            float(yx_position[1]) - yx_center[1],
+        ),
+        "mask": np.zeros(cutout_shape, dtype=bool),
+        "fwhm_area": np.nan,
+        "param_cov_xy": None,
+        "param_names": [],
+        "fit_ok": False,
+    }
+
+
 def fit_2d_gaussian(
     image,
     yx_position=None,
@@ -1080,24 +1203,25 @@ def fit_2d_gaussian(
         cy, cx = yx_position
     cutout = Cutout2D(image, (cx, cy), box_size)
 
-    if np.all(np.isnan(cutout.data)):
-        # The cutout contains only NaNs.
-        # This likely has happened because the cutout of the
-        # normalized_detection_image contains only NaNs, which
-        # is a result of make_radial_profile creating a central
-        # mask of NaNs. This can happen with a candidate close
-        # to the search_region_inner_bound.
+    finite_mask = np.logical_and(np.isfinite(cutout.data), cutout.data != 0.0)
 
-        raise RuntimeError(
-            f"The cutout image at position (y, x) = ({cy}, {cx}) "
-            "contains only NaNs. The issue might be caused by "
-            "make_radial_profile that is used for "
-            "normalized_detection_image. Perhaps there is a "
-            "candidate too close to the search_region_inner_bound? "
+    # Too few finite pixels to constrain even the 3-parameter fallback below.
+    # Historically an all-NaN cutout raised, which aborted the whole target: it
+    # is produced by make_radial_profile blanking every annulus a candidate's
+    # own companion mask covers, so a single candidate near the inner working
+    # angle could destroy an otherwise complete reduction.
+    if np.count_nonzero(finite_mask) < 6:
+        logger.warning(
+            "Gaussian fit at (y, x) = (%s, %s) has only %d usable pixels in its "
+            "%dx%d cutout; reporting an unfitted candidate. A fully masked cutout "
+            "usually means a candidate sits inside its own companion mask.",
+            cy, cx, int(np.count_nonzero(finite_mask)), box_size, box_size,
         )
+        return _failed_gaussian_fit_result((cy, cx), yx_center, cutout.shape)
 
-    # stamp = image[cy - box_size:cy + box_size, cx - box_size:cx + box_size].copy()
-    xx, yy = np.meshgrid(np.arange(box_size), np.arange(box_size))
+    # Cutout2D trims at the frame edge, so the model grid has to follow the
+    # cutout rather than box_size or the boolean indexing below misaligns.
+    xx, yy = np.meshgrid(np.arange(cutout.shape[1]), np.arange(cutout.shape[0]))
     yx_position_cutout = np.unravel_index(np.nanargmax(cutout.data), cutout.shape)
     gbounds = {
         "amplitude": (1e-9, None),
@@ -1109,8 +1233,6 @@ def fit_2d_gaussian(
     relative_yx = absolute_yx_to_relative_yx(yx_position, yx_center)
     rhophi = relative_yx_to_rhophi(relative_yx)
     phi = rhophi[1] * np.pi / 180.0
-
-    finite_mask = np.logical_and(np.isfinite(cutout.data), cutout.data != 0.0)
 
     g_init = models.Gaussian2D(
         amplitude=np.max(cutout.data[finite_mask]),
@@ -1160,8 +1282,41 @@ def fit_2d_gaussian(
             cov_xy = None
         return cov_xy, names
 
-    fitter = fitting.LevMarLSQFitter(calc_uncertainties=True)
-    par = fitter(g_init, xx[finite_mask], yy[finite_mask], cutout.data[finite_mask])
+    # LevMarLSQFitter enforces bounds by clipping inside the objective, so a
+    # parameter pushed past a bound lands in a flat region whose numerical
+    # Jacobian column is identically zero; MINPACK then returns NaN parameters
+    # and astropy raises NonFiniteValueError. TRF is genuinely bounded, which
+    # matters because Fit A leaves both widths and the orientation free and
+    # routinely drives x_stddev into its lower bound on speckle structure.
+    fitter = fitting.TRFLSQFitter(calc_uncertainties=True)
+    try:
+        par = fitter(g_init, xx[finite_mask], yy[finite_mask], cutout.data[finite_mask])
+    except Exception as error:
+        # Speckles are not Gaussian. When the free fit still fails, retry with
+        # the shape locked to the instrument PSF so only position and amplitude
+        # stay free; the outcome is flagged either way, never raised.
+        logger.warning(
+            "Free 2D Gaussian fit at (y, x) = (%s, %s) failed (%s); retrying with "
+            "the PSF shape held fixed.", cy, cx, type(error).__name__,
+        )
+        g_retry = g_init.copy()
+        g_retry.x_stddev = x_stddev
+        g_retry.y_stddev = y_stddev
+        g_retry.x_stddev.fixed = True
+        g_retry.y_stddev.fixed = True
+        g_retry.theta.fixed = True
+        fitter = fitting.TRFLSQFitter(calc_uncertainties=True)
+        try:
+            par = fitter(
+                g_retry, xx[finite_mask], yy[finite_mask], cutout.data[finite_mask]
+            )
+        except Exception as retry_error:
+            logger.warning(
+                "Constrained 2D Gaussian fit at (y, x) = (%s, %s) failed as well "
+                "(%s); reporting an unfitted candidate.",
+                cy, cx, type(retry_error).__name__,
+            )
+            return _failed_gaussian_fit_result((cy, cx), yx_center, cutout.shape)
     model = par(xx, yy)
     param_cov_xy, param_names = _extract_param_cov_xy(par)
 
@@ -1212,6 +1367,7 @@ def fit_2d_gaussian(
         "fwhm_area": fwhm_area,
         "param_cov_xy": param_cov_xy,
         "param_names": param_names,
+        "fit_ok": True,
     }
 
     return parameters
@@ -1272,6 +1428,12 @@ def fit_planet_parameters(
         fix_orientation=False,
     )
     fit_a_yx_orig = snr_image_parameters["yx_fit_position_orig"]
+    if not snr_image_parameters["fit_ok"]:
+        # Fits B and C clamp their centroid to Fit A's, so without it there is
+        # nothing to measure; report the candidate as unfitted across all three.
+        failed = summarize_2d_gauss_fit_result(snr_image_parameters)
+        return failed.copy(), failed.copy(), failed.copy()
+
     fit_a_start = (
         int(round(fit_a_yx_orig[0])),
         int(round(fit_a_yx_orig[1])),
@@ -1489,6 +1651,7 @@ def summarize_2d_gauss_fit_result(
     fitted_parameters["tangential_sigma_fit"] = [rt["sigma_t_fit"]]
     fitted_parameters["radial_sigma_cr"] = [rt["sigma_r_cr"]]
     fitted_parameters["tangential_sigma_cr"] = [rt["sigma_t_cr"]]
+    fitted_parameters["fit_ok"] = [bool(result_dictionary.get("fit_ok", True))]
 
     fitted_parameters = pd.DataFrame(fitted_parameters)
     return fitted_parameters
@@ -2334,8 +2497,46 @@ class DetectionAnalysis(object):
         self.empirical_correlation = empirical_correlation
 
     def find_approximate_candidate_positions(
-        self, snr_image, candidate_threshold=4.75, mask_radius=15
+        self,
+        snr_image,
+        candidate_threshold=4.75,
+        mask_radius=15,
+        max_candidates=DEFAULT_MAX_CANDIDATES,
+        mask_connected_region=True,
+        exclusion_radius_snr_scaling=True,
+        max_exclusion_radius_factor=DEFAULT_MAX_EXCLUSION_RADIUS_FACTOR,
     ):
+        """Iteratively pick significant peaks, masking each source before the next.
+
+        Parameters
+        ----------
+        snr_image : ndarray
+            Normalized detection map.
+        candidate_threshold : float
+            Significance a pixel must exceed to be considered.
+        mask_radius : float
+            Base radius of the disk blanked around an accepted peak; the radius
+            actually used scales with the peak's SNR unless disabled below.
+        max_candidates : int
+            Upper bound on the number of peaks returned, highest-SNR first. A
+            saturated frame (a bright binary, a badly centred reduction) can
+            otherwise yield hundreds, and every one of them costs a full
+            re-normalization downstream.
+        mask_connected_region : bool
+            Also blank the contiguous above-threshold region the peak belongs to.
+            Cheap, but on real data a bright source's contamination is a swarm of
+            separate blobs with sub-threshold gaps, so this alone is not enough —
+            the SNR scaling below is what reaches them.
+        exclusion_radius_snr_scaling : bool
+            Scale the exclusion radius as ``sqrt(snr / candidate_threshold)``. A
+            fixed radius is tuned for a marginal detection, but a 100σ binary
+            contaminates a far larger area, and each leftover blob re-enters the
+            loop as a spurious candidate. Marginal peaks keep the base radius, so
+            genuine close pairs are not merged.
+        max_exclusion_radius_factor : float
+            Cap on the scaling, as a multiple of ``mask_radius``. Without it a
+            very bright source would blank most of the search region.
+        """
         snr_image = np.ma.masked_array(snr_image)
 
         yx_dim = snr_image.shape
@@ -2344,8 +2545,13 @@ class DetectionAnalysis(object):
         significant_pixel_mask = np.logical_and(
             snr_image.data > candidate_threshold,
             np.isfinite(snr_image.data))
-        
+
         snr_image.mask = ~significant_pixel_mask
+
+        if mask_connected_region:
+            connected_labels, _ = ndimage.label(significant_pixel_mask)
+        else:
+            connected_labels = None
 
         candidates = {
             "x": [],
@@ -2357,9 +2563,12 @@ class DetectionAnalysis(object):
             "snr": [],
         }
 
-        candidate_index = 0
+        truncated = False
         while not np.all(snr_image.mask):
-            # candidates['candidate_index'].append(candidate_index)
+            if len(candidates["snr"]) >= max_candidates:
+                truncated = True
+                break
+
             candidates["snr"].append(snr_image.max())
 
             highest_value_position = np.unravel_index(
@@ -2379,12 +2588,31 @@ class DetectionAnalysis(object):
             candidate_mask = regressor_selection.make_signal_mask(
                 snr_image.shape,
                 highest_value_position,
-                mask_radius,
+                _scaled_exclusion_radius(
+                    candidates["snr"][-1],
+                    candidate_threshold,
+                    mask_radius,
+                    max_exclusion_radius_factor,
+                    enabled=exclusion_radius_snr_scaling,
+                ),
                 relative_pos=False,
                 yx_center=None,
             )
+            if connected_labels is not None:
+                peak_label = connected_labels[highest_value_position]
+                if peak_label > 0:
+                    candidate_mask = np.logical_or(
+                        candidate_mask, connected_labels == peak_label
+                    )
             snr_image.mask[candidate_mask] = True
-            candidate_index += 1
+
+        if truncated:
+            logger.warning(
+                "Candidate search stopped at the %d-candidate limit with "
+                "significant pixels remaining. The detection map is likely "
+                "dominated by a bright source or a reduction artefact.",
+                max_candidates,
+            )
 
         candidates = pd.DataFrame(candidates)
         self.candidates = candidates
@@ -2396,6 +2624,8 @@ class DetectionAnalysis(object):
         candidate_threshold=3.5,
         iterative_search_exclusion_radius=15,
         detection_products=None,
+        minimum_candidate_separation=DEFAULT_MINIMUM_CANDIDATE_SEPARATION,
+        max_candidates=DEFAULT_MAX_CANDIDATES,
     ):
         if detection_products is None:
             detection_products = self.detection_products
@@ -2420,12 +2650,22 @@ class DetectionAnalysis(object):
             detection_products["normalized_detection_cube"][detection_product_index],
             candidate_threshold=candidate_threshold,
             mask_radius=iterative_search_exclusion_radius,
+            max_candidates=max_candidates,
         )
 
-        # Exclude "detections" very close to the IWA of the reduction
-        mask_too_close = candidates["separation"] < smallest_separation_in_pixel
-        candidates = candidates[~mask_too_close]
-
+        # The reduction's own inner bound is not a usable floor on its own: with
+        # `search_region_inner_bound=1` the normalization is finite from 1 px, so
+        # this guard admitted the coronagraph centre residual as a candidate.
+        separation_floor = max(
+            float(smallest_separation_in_pixel), float(minimum_candidate_separation)
+        )
+        mask_too_close = candidates["separation"] < separation_floor
+        if mask_too_close.any():
+            logger.info(
+                "Dropping %d candidate(s) inside %.1f px of the star; the stellar "
+                "PSF core is not a detection region.",
+                int(mask_too_close.sum()), separation_floor,
+            )
         candidates = candidates[~mask_too_close].sort_values(
             "separation", ignore_index=False
         )
@@ -2603,6 +2843,8 @@ class DetectionAnalysis(object):
         wavelength_indices=None,
         candidate_threshold=4.0,
         iterative_search_exclusion_radius=15,
+        minimum_candidate_separation=DEFAULT_MINIMUM_CANDIDATE_SEPARATION,
+        max_candidates=DEFAULT_MAX_CANDIDATES,
     ):
         if detection_cube is None:
             detection_cube = self.detection_cube
@@ -2619,6 +2861,8 @@ class DetectionAnalysis(object):
                     detection_products=detection_products,
                     candidate_threshold=candidate_threshold,
                     iterative_search_exclusion_radius=iterative_search_exclusion_radius,
+                    minimum_candidate_separation=minimum_candidate_separation,
+                    max_candidates=max_candidates,
                 )
             )
 
@@ -2637,6 +2881,9 @@ class DetectionAnalysis(object):
         search_radius=15,
         mask_deviating=False,
         independent_channels=False,
+        minimum_candidate_separation=DEFAULT_MINIMUM_CANDIDATE_SEPARATION,
+        candidate_exclusion_radius=None,
+        max_candidates=DEFAULT_MAX_CANDIDATES,
     ):
         """
         Consolidate candidate detections with 2D Gaussian fitting and duplicate removal.
@@ -2743,7 +2990,11 @@ class DetectionAnalysis(object):
                 detection_products=detection_products,
                 wavelength_indices=wavelength_indices,
                 candidate_threshold=candidate_threshold,
-                iterative_search_exclusion_radius=search_radius,
+                iterative_search_exclusion_radius=_resolve_exclusion_radius(
+                    candidate_exclusion_radius, search_radius
+                ),
+                minimum_candidate_separation=minimum_candidate_separation,
+                max_candidates=max_candidates,
             )
 
         if len(candidates) == 0:
@@ -3851,6 +4102,9 @@ class DetectionAnalysis(object):
         candidate_threshold=4.75,
         inner_mask_radius=1,
         search_radius=15,
+        minimum_candidate_separation=DEFAULT_MINIMUM_CANDIDATE_SEPARATION,
+        candidate_exclusion_radius=None,
+        max_candidates=DEFAULT_MAX_CANDIDATES,
         good_fraction_threshold=0.05,
         theta_deviation_threshold=25,
         yx_fwhm_ratio_threshold=[1.1, 4.5],
@@ -4030,7 +4284,11 @@ class DetectionAnalysis(object):
             detection_products=detection_products,
             wavelength_indices=[0],
             candidate_threshold=candidate_threshold,
-            iterative_search_exclusion_radius=search_radius,
+            iterative_search_exclusion_radius=_resolve_exclusion_radius(
+                candidate_exclusion_radius, search_radius
+            ),
+            minimum_candidate_separation=minimum_candidate_separation,
+            max_candidates=max_candidates,
         )
         
         _, candidates_fit_initial = self.complete_candidate_table(
@@ -4041,6 +4299,9 @@ class DetectionAnalysis(object):
             candidate_threshold=candidate_threshold,
             search_radius=search_radius,
             mask_deviating=mask_deviating,
+            minimum_candidate_separation=minimum_candidate_separation,
+            candidate_exclusion_radius=candidate_exclusion_radius,
+            max_candidates=max_candidates,
         )
 
         if candidates_initial is None or len(candidates_initial) == 0:
@@ -4068,7 +4329,11 @@ class DetectionAnalysis(object):
                 detection_products=detection_products_masked,
                 wavelength_indices=[0], # only collapsed wavelength after template matching
                 candidate_threshold=candidate_threshold,
-                iterative_search_exclusion_radius=search_radius,
+                iterative_search_exclusion_radius=_resolve_exclusion_radius(
+                    candidate_exclusion_radius, search_radius
+                ),
+                minimum_candidate_separation=minimum_candidate_separation,
+                max_candidates=max_candidates,
             )
 
             _, candidates_fit_final = self.complete_candidate_table(
@@ -4079,6 +4344,9 @@ class DetectionAnalysis(object):
                 candidate_threshold=candidate_threshold,
                 search_radius=search_radius,
                 mask_deviating=mask_deviating,
+                minimum_candidate_separation=minimum_candidate_separation,
+                candidate_exclusion_radius=candidate_exclusion_radius,
+                max_candidates=max_candidates,
             )
             
             # Check if candidates survived the second iteration validation
@@ -4241,6 +4509,9 @@ class DetectionAnalysis(object):
         candidate_threshold=4.75,
         inner_mask_radius=1,
         search_radius=15,
+        minimum_candidate_separation=DEFAULT_MINIMUM_CANDIDATE_SEPARATION,
+        candidate_exclusion_radius=None,
+        max_candidates=DEFAULT_MAX_CANDIDATES,
         good_fraction_threshold=0.05,
         theta_deviation_threshold=25,
         yx_fwhm_ratio_threshold=[1.1, 4.5],
@@ -4260,29 +4531,45 @@ class DetectionAnalysis(object):
     ):
         if self.templates:
             for key in self.templates:
-                self.run_template_matching(
-                    template=self.templates[key],
-                    detection_threshold=detection_threshold,
-                    candidate_threshold=candidate_threshold,
-                    inner_mask_radius=inner_mask_radius,
-                    search_radius=search_radius,
-                    good_fraction_threshold=good_fraction_threshold,
-                    theta_deviation_threshold=theta_deviation_threshold,
-                    yx_fwhm_ratio_threshold=yx_fwhm_ratio_threshold,
-                    data_full=data_full,
-                    flux_psf_full=flux_psf_full,
-                    pa=pa,
-                    instrument=instrument,
-                    temporal_components_fraction=temporal_components_fraction,
-                    wavelength_indices=wavelength_indices,
-                    inverse_variance_full=inverse_variance_full,
-                    bad_frames=bad_frames,
-                    bad_pixel_mask_full=bad_pixel_mask_full,
-                    xy_image_centers=xy_image_centers,
-                    amplitude_modulation_full=amplitude_modulation_full,
-                    file_paths=file_paths,
-                    save=save,
-                )
+                try:
+                    self.run_template_matching(
+                        template=self.templates[key],
+                        detection_threshold=detection_threshold,
+                        candidate_threshold=candidate_threshold,
+                        inner_mask_radius=inner_mask_radius,
+                        search_radius=search_radius,
+                        minimum_candidate_separation=minimum_candidate_separation,
+                        candidate_exclusion_radius=candidate_exclusion_radius,
+                        max_candidates=max_candidates,
+                        good_fraction_threshold=good_fraction_threshold,
+                        theta_deviation_threshold=theta_deviation_threshold,
+                        yx_fwhm_ratio_threshold=yx_fwhm_ratio_threshold,
+                        data_full=data_full,
+                        flux_psf_full=flux_psf_full,
+                        pa=pa,
+                        instrument=instrument,
+                        temporal_components_fraction=temporal_components_fraction,
+                        wavelength_indices=wavelength_indices,
+                        inverse_variance_full=inverse_variance_full,
+                        bad_frames=bad_frames,
+                        bad_pixel_mask_full=bad_pixel_mask_full,
+                        xy_image_centers=xy_image_centers,
+                        amplitude_modulation_full=amplitude_modulation_full,
+                        file_paths=file_paths,
+                        save=save,
+                    )
+                except Exception:
+                    # One template failing must not cost the templates after it
+                    # (they run in dict order) nor the combined tables built from
+                    # whichever templates did succeed.
+                    logger.exception(
+                        "Template matching failed for the '%s' template; continuing "
+                        "with the remaining templates.", key,
+                    )
+                    template = self.templates[key]
+                    template.companion_table = None
+                    template.validated_companion_table = None
+                    template.validated_companion_table_short = None
 
     def plot_template_matched_contrasts(self):
 
@@ -4342,6 +4629,9 @@ class DetectionAnalysis(object):
         search_radius=15,
         mask_deviating=False,
         independent_channels=False,
+        minimum_candidate_separation=DEFAULT_MINIMUM_CANDIDATE_SEPARATION,
+        candidate_exclusion_radius=None,
+        max_candidates=DEFAULT_MAX_CANDIDATES,
     ):
         """Detect and fit the companion in each wavelength channel separately,
         then combine the channels that individually clear ``candidate_threshold``
@@ -4358,7 +4648,11 @@ class DetectionAnalysis(object):
         candidates = self.find_candidates_all_wavelengths(
             wavelength_indices=wavelength_indices,
             candidate_threshold=candidate_threshold,
-            iterative_search_exclusion_radius=search_radius,
+            iterative_search_exclusion_radius=_resolve_exclusion_radius(
+                candidate_exclusion_radius, search_radius
+            ),
+            minimum_candidate_separation=minimum_candidate_separation,
+            max_candidates=max_candidates,
         )
         if candidates is None or len(candidates) == 0:
             return None
@@ -4369,6 +4663,9 @@ class DetectionAnalysis(object):
             search_radius=search_radius,
             mask_deviating=mask_deviating,
             independent_channels=independent_channels,
+            minimum_candidate_separation=minimum_candidate_separation,
+            candidate_exclusion_radius=candidate_exclusion_radius,
+            max_candidates=max_candidates,
         )
         if candidates_fit is None:
             return None
@@ -4679,6 +4976,8 @@ class DetectionAnalysis(object):
         detection_threshold=5., candidate_threshold=4.75,
         use_spectral_correlation=False,
         inner_mask_radius=1, search_radius=15, good_fraction_threshold=0.05,
+        minimum_candidate_separation=DEFAULT_MINIMUM_CANDIDATE_SEPARATION,
+        candidate_exclusion_radius=None, max_candidates=DEFAULT_MAX_CANDIDATES,
         theta_deviation_threshold=25, yx_fwhm_ratio_threshold=[1.1, 4.5],
         save_initial_detection_products=True,
         per_channel_min_channel_fraction=0.5,
@@ -4713,6 +5012,9 @@ class DetectionAnalysis(object):
             candidate_threshold=candidate_threshold,
             inner_mask_radius=inner_mask_radius,
             search_radius=search_radius,
+            minimum_candidate_separation=minimum_candidate_separation,
+            candidate_exclusion_radius=candidate_exclusion_radius,
+            max_candidates=max_candidates,
             good_fraction_threshold=good_fraction_threshold,
             theta_deviation_threshold=theta_deviation_threshold,
             yx_fwhm_ratio_threshold=yx_fwhm_ratio_threshold,
@@ -4731,17 +5033,34 @@ class DetectionAnalysis(object):
             save=True,
         )
         
-        self.plot_template_matched_contrasts()
+        try:
+            self.plot_template_matched_contrasts()
+        except Exception:
+            # Diagnostics only; never worth losing the tables below over.
+            logger.exception("Contrast plotting failed; continuing.")
 
         # Per-channel astrometry (template-independent) drives the reported
         # position/σ; the template collapse is optimal for detection SNR, not
         # for astrometry. Measured once here and merged into both overall tables.
-        self.per_channel_astrometry = self.measure_per_channel_astrometry(
-            wavelength_indices=wavelength_indices,
-            candidate_threshold=candidate_threshold,
-            search_radius=search_radius,
-            independent_channels=per_channel_independent_channels,
-        )
+        # It is a refinement of an astrometry the collapse already provides, so
+        # a failure here must not cost the overall tables — which is exactly what
+        # used to happen, since they are written after this call.
+        try:
+            self.per_channel_astrometry = self.measure_per_channel_astrometry(
+                wavelength_indices=wavelength_indices,
+                candidate_threshold=candidate_threshold,
+                search_radius=search_radius,
+                independent_channels=per_channel_independent_channels,
+                minimum_candidate_separation=minimum_candidate_separation,
+                candidate_exclusion_radius=candidate_exclusion_radius,
+                max_candidates=max_candidates,
+            )
+        except Exception:
+            logger.exception(
+                "Per-channel astrometry failed; falling back to the "
+                "template-collapse astrometry for the combined tables."
+            )
+            self.per_channel_astrometry = None
         if self.per_channel_astrometry is not None:
             output_dir_matching = os.path.join(
                 self.reduction_parameters.result_folder, "template_matching/"

--- a/src/trap/parameters.py
+++ b/src/trap/parameters.py
@@ -238,6 +238,18 @@ class DetectionParameters:
     stellar_parameters: StellarParameters = field(default_factory=StellarParameters)
     search_radius: int = 11
     inner_mask_radius: int = 1
+    # Pixels inside `search_region_inner_bound` are reduced to feed the annulus
+    # statistics, not because a companion there could be characterized: the
+    # stellar PSF core is coronagraph-attenuated, and a candidate closer in than
+    # this would be masked by its own companion mask when the noise profile is
+    # rebuilt. Candidates below this separation are dropped before any fit.
+    minimum_candidate_separation: float = 5.0
+    # `search_radius` doubles as the cross-template/cross-channel association
+    # radius, so widening it to swallow a bright source's footprint would also
+    # start merging genuinely distinct sources. Set this to decouple the two;
+    # None keeps the historical behaviour of reusing `search_radius`.
+    candidate_exclusion_radius: Optional[int] = None
+    max_candidates: int = 50
     good_fraction_threshold: float = 0.05
     theta_deviation_threshold: float = 25.0
     yx_fwhm_ratio_threshold: Tuple[float, float] = (1.1, 4.5)

--- a/tests/test_astrometry_uncertainty.py
+++ b/tests/test_astrometry_uncertainty.py
@@ -55,20 +55,26 @@ def test_fit_2d_gaussian_returns_param_cov_on_clean_source():
 
 
 def test_fit_2d_gaussian_handles_singular_fit():
-    """All-NaN cutout region should raise, unchanged by the covariance additions."""
+    """An unfittable cutout reports `fit_ok=False` rather than raising.
+
+    It used to raise, which aborted the whole target for one bad candidate.
+    """
     size = 21
     image, _ = _make_isotropic_gaussian(size=size, amplitude=50.0, sigma=1.5, noise=0.5)
     image[9:12, 9:12] = np.nan
     yx_center = (size // 2, size // 2)
-    with pytest.raises(RuntimeError):
-        detection.fit_2d_gaussian(
-            image,
-            yx_position=(10, 10),
-            yx_center=yx_center,
-            x_stddev=1.5,
-            y_stddev=1.5,
-            box_size=3,
-        )
+    result = detection.fit_2d_gaussian(
+        image,
+        yx_position=(10, 10),
+        yx_center=yx_center,
+        x_stddev=1.5,
+        y_stddev=1.5,
+        box_size=3,
+    )
+    assert result["fit_ok"] is False
+    assert np.isnan(result["parameters"].amplitude.value)
+    # The candidate position is echoed back so the row stays traceable.
+    assert result["yx_fit_position_orig"] == (10.0, 10.0)
 
 
 def test_fit_2d_gaussian_fixed_position_clamps_centroid():

--- a/tests/test_detection_robustness.py
+++ b/tests/test_detection_robustness.py
@@ -1,0 +1,272 @@
+"""Regression tests for the detection failure modes seen on SPHERE/IRDIS survey runs.
+
+Two production crashes motivated these: a bounded LevMar fit that returned NaN
+parameters on speckle structure, and a candidate at 1 px separation whose own
+companion mask blanked every annulus it needed. Both aborted the entire target
+and, with it, the combined companion tables.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from astropy.modeling import models
+
+from trap import detection
+
+
+def _speckle_cutout_image(size=41, seed=3):
+    """Bipolar speckle-like structure with no Gaussian core to converge on."""
+    rng = np.random.default_rng(seed)
+    y, x = np.mgrid[:size, :size]
+    image = 12.0 * np.sin(x * 0.9) * np.cos(y * 0.7)
+    image += 6.0 * np.sin((x + y) * 0.35)
+    image += rng.normal(0.0, 1.0, (size, size))
+    return image
+
+
+class TestFitFailureIsNonFatal:
+    def test_all_nan_cutout_returns_failed_result(self):
+        image = np.full((31, 31), np.nan)
+        result = detection.fit_2d_gaussian(
+            image, yx_position=(15, 15), box_size=11, fix_width=False,
+            fix_orientation=False,
+        )
+        assert result["fit_ok"] is False
+        assert result["param_cov_xy"] is None
+        assert not np.any(result["mask"])
+
+    def test_speckle_structure_never_raises(self):
+        """Fit A is fully free, which is what drove x_stddev into its bound."""
+        image = _speckle_cutout_image()
+        for yx in [(y, x) for y in range(8, 33, 3) for x in range(8, 33, 3)]:
+            result = detection.fit_2d_gaussian(
+                image, yx_position=yx, box_size=11,
+                fix_width=False, fix_orientation=False,
+            )
+            assert "fit_ok" in result
+
+    def test_clean_source_still_fits_accurately(self):
+        """The fitter swap must not cost accuracy on a well-behaved source."""
+        y, x = np.mgrid[:41, :41]
+        image = models.Gaussian2D(50.0, 22.4, 18.6, 1.5, 2.4, 0.4)(x, y)
+        result = detection.fit_2d_gaussian(
+            image, yx_position=(19, 22), box_size=11,
+            fix_width=False, fix_orientation=False,
+        )
+        assert result["fit_ok"] is True
+        assert result["yx_fit_position_orig"][0] == pytest.approx(18.6, abs=0.05)
+        assert result["yx_fit_position_orig"][1] == pytest.approx(22.4, abs=0.05)
+        assert result["parameters"].amplitude.value == pytest.approx(50.0, rel=0.02)
+
+    def test_edge_cutout_does_not_raise(self):
+        """Cutout2D trims at the frame edge, so the model grid must follow it."""
+        y, x = np.mgrid[:41, :41]
+        image = models.Gaussian2D(50.0, 2.0, 2.0, 1.5, 1.5, 0.0)(x, y)
+        result = detection.fit_2d_gaussian(
+            image, yx_position=(2, 2), box_size=11,
+            fix_width=False, fix_orientation=False,
+        )
+        assert "fit_ok" in result
+
+    def test_failed_fit_summarizes_into_a_row(self):
+        failed = detection._failed_gaussian_fit_result((30.0, 40.0), (25.0, 25.0), (11, 11))
+        row = detection.summarize_2d_gauss_fit_result(failed)
+        assert len(row) == 1
+        assert row["fit_ok"].iloc[0] is np.False_ or row["fit_ok"].iloc[0] is False
+        assert np.isnan(row["amplitude"].iloc[0])
+        assert row["x"].iloc[0] == 40.0
+
+
+class TestAnnulusFallback:
+    def _fully_masked_inner_annuli(self, minimum_annulus_pixels):
+        rng = np.random.default_rng(0)
+        data = rng.normal(0.0, 1.0, (61, 61))
+        companion_mask = np.hypot(*(np.mgrid[:61, :61] - 30)) < 11
+        profile, _ = detection.make_radial_profile(
+            data, (1, 20), bin_width=3.0, operation="mad_std",
+            known_companion_mask=companion_mask,
+            minimum_annulus_pixels=minimum_annulus_pixels,
+        )
+        radius = np.hypot(*(np.mgrid[:61, :61] - 30))
+        inner = (radius >= 2.5) & (radius < 3.5)
+        return profile[inner]
+
+    def test_fallback_keeps_the_annulus_finite(self):
+        assert np.all(np.isfinite(self._fully_masked_inner_annuli(10)))
+
+    def test_disabling_the_fallback_restores_nan(self):
+        assert np.all(np.isnan(self._fully_masked_inner_annuli(0)))
+
+
+class TestAdaptiveCompanionMask:
+    @pytest.mark.parametrize(
+        "separation,expected",
+        [(1.0, 3.0), (5.0, 4.0), (8.0, 7.0), (12.0, 11.0), (40.0, 11.0)],
+    )
+    def test_radius_is_capped_by_separation_and_floored_by_the_psf(
+        self, separation, expected
+    ):
+        radius = detection._adaptive_companion_mask_radius(
+            (separation, 0.0), companion_mask_radius=11, minimum_companion_mask_radius=3.0
+        )
+        assert radius == pytest.approx(expected)
+
+    def test_close_companion_no_longer_blanks_its_own_annuli(self):
+        rng = np.random.default_rng(1)
+        detection_image = np.stack(
+            [rng.normal(0, 1, (61, 61)) for _ in range(3)]
+        )
+        normalized, _, _, _ = detection.make_contrast_curve(
+            detection_image, bin_width=3.0, companion_mask_radius=11,
+            yx_known_companion_position=np.array([[-5.0, 0.0]]),
+        )
+        radius = np.hypot(*(np.mgrid[:61, :61] - 30))
+        inner = (radius >= 2.5) & (radius < 8.5)
+        assert np.any(np.isfinite(normalized[inner]))
+
+
+class _PeakFinder(detection.DetectionAnalysis):
+    def __init__(self):
+        pass
+
+
+class TestExclusionRadiusScaling:
+    def _bright_source_with_wing_blobs(self):
+        """A 100σ source plus detached blobs, as a real binary produces."""
+        y, x = np.mgrid[:121, :121]
+        image = np.zeros((121, 121))
+        image += models.Gaussian2D(100.0, 60.0, 40.0, 1.5, 1.5, 0.0)(x, y)
+        for dy, dx in [(9, 6), (-8, 11), (14, -5), (-13, -9), (7, 17)]:
+            image += models.Gaussian2D(7.0, 60.0 + dx, 40.0 + dy, 1.2, 1.2, 0.0)(x, y)
+        # A faint, genuinely separate source far away must survive.
+        image += models.Gaussian2D(6.0, 20.0, 100.0, 1.4, 1.4, 0.0)(x, y)
+        return image
+
+    def test_scaling_absorbs_the_wing_blobs(self):
+        finder = _PeakFinder()
+        unscaled = finder.find_approximate_candidate_positions(
+            self._bright_source_with_wing_blobs(), candidate_threshold=4.75,
+            mask_radius=11, exclusion_radius_snr_scaling=False,
+            mask_connected_region=False,
+        )
+        scaled = finder.find_approximate_candidate_positions(
+            self._bright_source_with_wing_blobs(), candidate_threshold=4.75,
+            mask_radius=11, exclusion_radius_snr_scaling=True,
+        )
+        assert len(scaled) < len(unscaled)
+        # The distant faint source is not swallowed by the bright one's mask.
+        assert np.any(scaled["snr"] < 10.0)
+
+    def test_marginal_peaks_keep_the_base_radius(self):
+        radius = detection._scaled_exclusion_radius(
+            5.0, candidate_threshold=4.75, mask_radius=11, max_factor=2.5
+        )
+        assert radius == pytest.approx(11.0, rel=0.05)
+
+    def test_scaling_is_capped(self):
+        radius = detection._scaled_exclusion_radius(
+            10000.0, candidate_threshold=4.75, mask_radius=11, max_factor=2.5
+        )
+        assert radius == pytest.approx(27.5)
+
+    def test_scaling_can_be_disabled(self):
+        radius = detection._scaled_exclusion_radius(
+            10000.0, candidate_threshold=4.75, mask_radius=11, max_factor=2.5,
+            enabled=False,
+        )
+        assert radius == 11
+
+
+class TestCandidateCap:
+    def test_saturated_map_is_truncated(self):
+        rng = np.random.default_rng(5)
+        image = rng.uniform(6.0, 9.0, (201, 201))
+        finder = _PeakFinder()
+        candidates = finder.find_approximate_candidate_positions(
+            image, candidate_threshold=4.75, mask_radius=3, max_candidates=7,
+            exclusion_radius_snr_scaling=False, mask_connected_region=False,
+        )
+        assert len(candidates) == 7
+
+
+class TestExclusionRadiusIsDecoupled:
+    def test_explicit_exclusion_radius_overrides_search_radius(self):
+        assert detection._resolve_exclusion_radius(25, 11) == 25
+
+    def test_none_falls_back_to_search_radius(self):
+        assert detection._resolve_exclusion_radius(None, 11) == 11
+
+
+class _CandidateFinder(detection.DetectionAnalysis):
+    def __init__(self, normalized_image):
+        self.wavelength_indices = np.array([0])
+        self.detection_products = {
+            "normalized_detection_cube": np.array([normalized_image]),
+            "contrast_tables": [
+                pd.DataFrame(
+                    {
+                        "sep (pix)": np.arange(1, 40, dtype=float),
+                        "snr_normalization": np.ones(39),
+                    }
+                )
+            ],
+        }
+
+
+class TestMinimumCandidateSeparation:
+    def _image_with_a_central_and_an_outer_peak(self):
+        image = np.zeros((81, 81))
+        y, x = np.mgrid[:81, :81]
+        # One residual 2 px from the star, one genuine source at 25 px.
+        image += models.Gaussian2D(9.0, 42.0, 40.0, 1.4, 1.4, 0.0)(x, y)
+        image += models.Gaussian2D(9.0, 65.0, 40.0, 1.4, 1.4, 0.0)(x, y)
+        return image
+
+    def test_central_residual_is_dropped(self):
+        finder = _CandidateFinder(self._image_with_a_central_and_an_outer_peak())
+        candidates = finder.find_candidates(
+            candidate_threshold=4.75, iterative_search_exclusion_radius=11,
+            minimum_candidate_separation=5.0,
+        )
+        assert len(candidates) == 1
+        assert candidates["separation"].iloc[0] == pytest.approx(25.0, abs=1.0)
+
+    def test_zero_floor_keeps_it(self):
+        """Guards against the test passing for an unrelated reason."""
+        finder = _CandidateFinder(self._image_with_a_central_and_an_outer_peak())
+        candidates = finder.find_candidates(
+            candidate_threshold=4.75, iterative_search_exclusion_radius=11,
+            minimum_candidate_separation=0.0,
+        )
+        assert len(candidates) == 2
+
+
+class _FailingTemplates(detection.DetectionAnalysis):
+    """Two templates where the first raises, mimicking the T-type failure."""
+
+    def __init__(self):
+        self.templates = {"bad": _Template("bad"), "good": _Template("good")}
+        self.visited = []
+
+    def run_template_matching(self, template=None, **kwargs):
+        self.visited.append(template.name)
+        if template.name == "bad":
+            raise RuntimeError("template matching blew up")
+        template.companion_table = "result"
+
+
+class _Template:
+    def __init__(self, name):
+        self.name = name
+        self.companion_table = None
+        self.validated_companion_table = None
+        self.validated_companion_table_short = None
+
+
+class TestTemplateErrorIsolation:
+    def test_a_failing_template_does_not_stop_the_others(self):
+        analysis = _FailingTemplates()
+        analysis.match_all_templates()
+        assert analysis.visited == ["bad", "good"]
+        assert analysis.templates["good"].companion_table == "result"
+        assert analysis.templates["bad"].companion_table is None


### PR DESCRIPTION
### 📌 Description

I ran four SPHERE/IRDIS targets through detection on MPCDF and two of them died, taking
their combined companion tables with them. Both crashes reproduce from the saved products,
so this branch fixes the two root causes, stops a single bad candidate from being fatal in
the first place, and adds an SNR-scaled exclusion radius for the bright-binary case that
surfaced along the way.

### 📌 Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### 🚨 Motivation and Context

**1. `LevMarLSQFitter` returns NaN parameters on bounded fits.**
`fit_2d_gaussian` used `LevMarLSQFitter`, which enforces bounds by clipping *inside* the
objective function. A parameter driven past a bound therefore sits in a flat region whose
numerical Jacobian column is zero, MINPACK hands back NaN parameters, and astropy raises
`NonFiniteValueError`. Fit A leaves both widths and the orientation free, so this fires on
ordinary speckle structure — 4 of 72,464 above-threshold positions across the four targets,
and every one of them fatal.

Swapped to `TRFLSQFitter`, which is genuinely bounded and is what astropy recommends for
bounded models. Behind it: a fixed-shape retry, and behind that a NaN row carrying
`fit_ok=False`. Nothing in the fit path raises any more — an unfittable cutout, including
the all-NaN case that used to raise `RuntimeError`, is reported rather than thrown. I also
fixed the model grid misalignment for cutouts trimmed at the frame edge, which I found
while reading that code.

**2. A candidate at the inner working angle destroys its own noise profile.**
With `search_region_inner_bound=1` the contrast table is finite from 1 px out, so the
`smallest_separation_in_pixel` guard happily admitted a 7σ "candidate" 1 px from the star —
the coronagraph centre residual. Rebuilding the noise profile with that candidate masked at
`companion_mask_radius=11` then blanked every annulus from 1 to 8 px, leaving the
candidate's own fit cutout entirely NaN. Guarded three ways, because any one of them alone
felt like it was papering over the others:

- new `DetectionParameters.minimum_candidate_separation` (5 px) drops candidates inside the
  stellar PSF core,
- `make_radial_profile` falls back to the un-masked annulus statistic below
  `minimum_annulus_pixels` (10) instead of writing NaN,
- a companion's exclusion radius is capped at `separation - 1` so it cannot swallow the
  annuli it depends on.

**3. Neither failure should have cost the overall tables.**
This is the part that actually annoyed me. `match_all_templates` iterates templates in dict
order, and `measure_per_channel_astrometry` runs *before* the overall tables are written —
so one bad fit lost every later template and both `overall_*.csv` files, even though the
per-template tables were already complete on disk and per-channel astrometry is only a
refinement. Each template, the contrast plotting, and the per-channel astrometry are now
individually log-and-continue, and the combined tables are built from whatever succeeded.

**4. A fixed exclusion radius cannot cope with a bright binary.**
Not a crash, but it came out of the same dataset. The iterative candidate search blanks a
disc of fixed radius around each accepted peak. That radius is tuned for a marginal
detection; a 125σ binary's contamination is not one wide source but a swarm of detached
above-threshold blobs (42 connected components on HD_140408), which re-enter the search as
spurious candidates. The exclusion radius now scales as
`sqrt(snr / candidate_threshold)`, clipped to `[1, 2.5] ×` the base radius, and the peak's
connected above-threshold region is masked alongside the disc.

Two honest caveats on that last item, since they matter for review:

- The `sqrt` form is a **choice, not a fit**. It is monotonic, anchored at 1.0 at threshold,
  and sub-linear, which is the behaviour I wanted; there is no derivation behind the
  exponent. (A Gaussian-wing argument would give something logarithmic in SNR, but the
  contamination is speckle/ADI residual structure, not Gaussian wings, so neither form is
  first-principles.)
- The only empirically anchored number is `max_exclusion_radius_factor = 2.5`, and it is
  anchored to a single target: on HD_140408, a radius of 11 px absorbs 4 of those 42
  components and 25 px absorbs 29, so 2.5 × 11 = 27.5 px sits just past the knee. The cap
  binds above ~30σ, which means the binary that motivated the change never exercised the
  `sqrt` at all. What the four-target run below establishes is that this doesn't *break*
  anything — it is validation, not calibration. Real calibration would need injected
  sources over an SNR × separation grid, and I'd expect it to add a separation term rather
  than change the exponent.

Also added while in here: `candidate_exclusion_radius` decouples the search exclusion
radius from `search_radius` (which doubles as the cross-template and cross-channel
association radius, so widening one used to silently widen the other; `None` keeps the old
shared behaviour), and `max_candidates` (50) bounds the previously unlimited candidate
loop — every candidate costs a full contrast-table renormalization, so a saturated map was
a runtime hazard as much as a scientific one. Truncation is logged.

### ✅ Checklist

- [x] I’ve tested the changes locally.
- [x] I’ve updated documentation as necessary.
- [x] My changes follow the project's coding style and conventions.
- [x] All tests pass successfully.

### 🔍 How to test/review

Unit tests (new module `tests/test_detection_robustness.py`, 272 lines):

```
pixi run -e test pytest tests/test_detection_robustness.py tests/test_astrometry_uncertainty.py -q
# 50 passed
```

End-to-end re-run of the four IRDIS targets that originally crashed, forcing only
detection (`config.steps.force = {"run_trap_detection"}` in the spherical driver). Exit 0,
1:50 wall for all four, no error/traceback/crash lines in 3863 log lines:

| target | detections | validated | per-channel astrometry rows | crash report |
|---|---|---|---|---|
| HD_140408 | 12 | 2 | 11 | none |
| HD_3795 | 7 | 3 | 6 | none |
| \*_83_Cnc | 15 | 2 | 6 | none |
| \*_iot_Vir | 11 | 4 | 7 | none |

Before this branch, HD_140408 and HD_3795 both wrote `trap_crash_report.txt` and neither
produced any `overall_*.csv` or `per_channel_astrometry.csv`; HD_140408 had only the L-type
template outputs (it died mid-T-type). What to look for now:

1. All four targets write all five products, and the stale crash reports are gone.
2. `fit_ok` is `True` for every row on every target — the `TRFLSQFitter` swap holds on real
   speckle.
3. HD_3795's innermost surviving candidate is at 26.8 px rather than 1.0 px — nothing gets
   through the 5 px floor.
4. HD_140408's binary resolves to 2 validated sources (35.0 px and 81.6 px) instead of a
   blob swarm; the candidate list went 18/14 → 9/6 per channel.
5. The three clean targets are unchanged by the SNR scaling, including one with a real 30σ
   source.

### 🔖 Related Issues/Tickets

No tracking issue — found while reducing on MPCDF. Touches the same code as #8 (detection
module size); this branch does not attempt that split.
